### PR TITLE
Switch to using bytearray which is mutable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 build/
 nativepython.egg-info
+.python-version

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ flask-cors = "*"
 requests = "*"
 websockets = "*"
 llvmlite = "*"
-nativepython = {path = "."}
+nativepython = {editable = true,path = "."}
 
 [requires]
 python_version = "3.6.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5bd628eab7c5b858e9573afb6a4f8ed290500d7a4ec1bdee26ad45380bb0946e"
+            "sha256": "5e0be4272609cb24e95e0b024a652dfddd88148e74940cde5431175813e25c07"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -203,6 +203,7 @@
             "version": "==1.1.0"
         },
         "nativepython": {
+            "editable": true,
             "path": "."
         },
         "nose": {

--- a/object_database/algebraic_protocol.py
+++ b/object_database/algebraic_protocol.py
@@ -23,7 +23,7 @@ class AlgebraicProtocol(asyncio.Protocol):
         self.receiveType = receiveType
         self.sendType = sendType
         self.transport = None
-        self.buffer = bytes()
+        self.buffer = bytearray()
         self.writelock = threading.Lock()
 
     def sendMessage(self, msg):
@@ -32,7 +32,7 @@ class AlgebraicProtocol(asyncio.Protocol):
 
             dataToSend = serialize(self.sendType, msg)
             dataToSend = longToString(len(dataToSend)) + dataToSend
-            
+
             with self.writelock:
                 #for some insane reason, sending a 5 byte message causes the socket to disconnect on the other
                 #side. Sending the 5 bytes in multiple messages does not, nor does sending an extra packet


### PR DESCRIPTION
bytes() returns an immutable object, but a buffer is usually mutable. I suspect this change will improve performance.