### PR TITLE
Build process fixups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 build/
 nativepython.egg-info
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,4 @@ clean:
 	rm -rf build/
 	rm -rf nativepython.egg-info/
 	rm -f nose.*.log
+	rm -f typed_python/_types.cpython-*.so

--- a/Pipfile
+++ b/Pipfile
@@ -16,7 +16,7 @@ flask-cors = "*"
 requests = "*"
 websockets = "*"
 llvmlite = "*"
-nativepython = {path = "."}
+nativepython = {editable = true,path = "."}
 
 [requires]
 python_version = "3.6.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5bd628eab7c5b858e9573afb6a4f8ed290500d7a4ec1bdee26ad45380bb0946e"
+            "sha256": "5e0be4272609cb24e95e0b024a652dfddd88148e74940cde5431175813e25c07"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -203,6 +203,7 @@
             "version": "==1.1.0"
         },
         "nativepython": {
+            "editable": true,
             "path": "."
         },
         "nose": {


### PR DESCRIPTION
# Purpose
I noticed after bringing the new changes from the `dev` branch that the tests were failing, presumably because an older `.so` binary was being used (the errors were pointing to object missing fields added in recent commits)

# Approach
- Install nativepython in editable mode
- Remove the *.so file under typed_python during clean-up
- Ignore the .python-version file

# Testing
- Ran `make clean`
- Made sure that the `*.so` files were gone
- Ran the tests with `make test` and watched them fail because of the missing `*.so` file
- Ran `make install` to re-build the package
- Ran `make test` and confirmed that all the tests passed.