### PR TITLE
Enable and mandate the use of SSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,8 @@
 __pycache__
 build/
 nativepython.egg-info
-.python-version
+
+# leading slash means only match at repo-root level
+/.python-version
+/testcert.key
+/testcert.cert

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 install:
 	pipenv install --system --deploy
 
-test:
+test: testcert.cert testcert.key
 	./test.py -s
 
 docker-build:
@@ -17,8 +17,14 @@ docker-web:
 	./build.sh -w
 
 
+testcert.cert testcert.key:
+	openssl req -x509 -newkey rsa:2048 -keyout testcert.key -nodes \
+		-out testcert.cert -sha256 -days 1000 \
+		-subj '/C=US/ST=New York/L=New York/CN=localhost'
+
 clean:
 	rm -rf build/
 	rm -rf nativepython.egg-info/
 	rm -f nose.*.log
 	rm -f typed_python/_types.cpython-*.so
+	rm -f testcert.cert testcert.key

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-install:
+install: testcert.cert testcert.key
 	pipenv install --system --deploy
 
 test: testcert.cert testcert.key

--- a/object_database/algebraic_protocol.py
+++ b/object_database/algebraic_protocol.py
@@ -53,7 +53,6 @@ class AlgebraicProtocol(asyncio.Protocol):
 
     def connection_made(self, transport):
         self.transport = transport
-        self.transport._sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
         self.onConnected()
 
     def data_received(self, data):

--- a/object_database/algebraic_protocol_test.py
+++ b/object_database/algebraic_protocol_test.py
@@ -92,7 +92,7 @@ class AlgebraicProtocolTests(unittest.TestCase):
         #     openssl req -x509 -newkey rsa:2048 -keyout testcert.key -nodes \
         #                 -out testcert.cert -sha256 -days 1000
         #
-        # use 'localhost' as Common Name
+        # use 'localhost' as Common Name (CN)
         loop = self.loop
         host = 'localhost'
         port = 8888

--- a/object_database/algebraic_protocol_test.py
+++ b/object_database/algebraic_protocol_test.py
@@ -12,19 +12,22 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from typed_python import *
 from object_database.algebraic_protocol import AlgebraicProtocol
+from typed_python import Alternative
 
-import unittest
 import asyncio
-import threading
 import queue
+import ssl
+import threading
+import unittest
+
 
 Message = Alternative(
     "Message",
     Ping = {},
     Pong = {}
     )
+
 
 class PingPongProtocol(AlgebraicProtocol):
     def __init__(self):
@@ -34,6 +37,7 @@ class PingPongProtocol(AlgebraicProtocol):
         if m.matches.Ping:
             self.sendMessage(Message.Pong())
 
+
 class SendAndReturn(AlgebraicProtocol):
     def __init__(self, messageToSend, responseQueue):
         AlgebraicProtocol.__init__(self, Message, Message)
@@ -41,15 +45,25 @@ class SendAndReturn(AlgebraicProtocol):
         self.responseQueue = responseQueue
 
     def onConnected(self):
+        print("SEND")
         self.sendMessage(self.messageToSend)
 
     def messageReceived(self, msg):
         self.responseQueue.put(msg)
         self.transport.close()
 
+
 class AlgebraicProtocolTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.loop = asyncio.get_event_loop()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loop.close()
+
     def test_basic_send_and_receive(self):
-        loop = asyncio.get_event_loop()
+        loop = self.loop
 
         # Each client connection will create a new protocol instance
         serverCoro = loop.create_server(PingPongProtocol, '127.0.0.1', 8888)
@@ -69,4 +83,51 @@ class AlgebraicProtocolTests(unittest.TestCase):
 
         server.close()
         loop.run_until_complete(server.wait_closed())
-        loop.close()
+
+    def test_basic_send_and_receive_with_ssl(self):
+        # https://gist.github.com/messa/22398173f039d1230e32
+        #
+        # Command to generate the self-signed key:
+        #
+        #     openssl req -x509 -newkey rsa:2048 -keyout testcert.key -nodes \
+        #                 -out testcert.cert -sha256 -days 1000
+        #
+        # use 'localhost' as Common Name
+        loop = self.loop
+        host = 'localhost'
+        port = 8888
+
+        srv_ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        srv_ssl_ctx.load_cert_chain('testcert.cert', 'testcert.key')
+        # Each client connection will create a new protocol instance
+        serverCoro = loop.create_server(
+            PingPongProtocol, host, port,
+            ssl=srv_ssl_ctx,
+            #ssl_handshake_timeout=2
+        )
+
+        server = loop.run_until_complete(serverCoro)
+
+        cli_ssl_ctx = ssl.create_default_context(
+            ssl.Purpose.SERVER_AUTH,
+            cafile='testcert.cert'
+        )
+
+        q = queue.Queue()
+
+        clientCoro = loop.create_connection(
+            lambda: SendAndReturn(Message.Ping(), q),
+            host,
+            port,
+            ssl=cli_ssl_ctx
+        )
+        try:
+            loop.run_until_complete(clientCoro)
+        except Exception as e:
+            import pdb; pdb.set_trace()
+            print(e)
+        finally:
+            self.assertEqual(q.get(timeout=1.0), Message.Pong())
+
+        server.close()
+        loop.run_until_complete(server.wait_closed())

--- a/object_database/algebraic_protocol_test.py
+++ b/object_database/algebraic_protocol_test.py
@@ -45,7 +45,6 @@ class SendAndReturn(AlgebraicProtocol):
         self.responseQueue = responseQueue
 
     def onConnected(self):
-        print("SEND")
         self.sendMessage(self.messageToSend)
 
     def messageReceived(self, msg):
@@ -56,6 +55,7 @@ class SendAndReturn(AlgebraicProtocol):
 class AlgebraicProtocolTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+        # use common eventloop for all tests in class
         cls.loop = asyncio.get_event_loop()
 
     @classmethod

--- a/object_database/algebraic_protocol_test.py
+++ b/object_database/algebraic_protocol_test.py
@@ -103,7 +103,6 @@ class AlgebraicProtocolTests(unittest.TestCase):
         serverCoro = loop.create_server(
             PingPongProtocol, host, port,
             ssl=srv_ssl_ctx,
-            #ssl_handshake_timeout=2
         )
 
         server = loop.run_until_complete(serverCoro)

--- a/object_database/database_frontend_test.py
+++ b/object_database/database_frontend_test.py
@@ -27,9 +27,8 @@ class ObjectDatabaseFrontEnd(unittest.TestCase):
                 sys.executable,
                 os.path.join(own_dir, "frontends", "database_server.py"),
                 "localhost", "8888",
-                "--inmem"],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL
+                os.path.join(own_dir, "..", "testcert.cert"),
+                "--inmem"]
                 )
 
             time.sleep(.5)

--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -21,6 +21,8 @@ from object_database.database_connection import TransactionListener, DatabaseCon
 from object_database.tcp_server import TcpServer, connect
 from object_database.inmem_server import InMemServer
 from object_database.persistence import InMemoryPersistence, RedisPersistence
+from object_database.util import configureLogging
+
 import object_database.messages as messages
 import queue
 import unittest
@@ -33,7 +35,8 @@ import threading
 import random
 import time
 import psutil
-from object_database.util import configureLogging
+import ssl
+
 
 def currentMemUsageMb(residentOnly=True):
     if residentOnly:
@@ -1523,7 +1526,10 @@ class ObjectDatabaseOverChannelTests(unittest.TestCase, ObjectDatabaseTests):
 class ObjectDatabaseOverSocketTests(unittest.TestCase, ObjectDatabaseTests):
     def setUp(self):
         self.mem_store = InMemoryPersistence()
-        self.server = TcpServer(host="localhost", port=8888, mem_store=self.mem_store)
+        sc = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+        sc.load_cert_chain('testcert.cert', 'testcert.key')
+
+        self.server = TcpServer(host="localhost", port=8888, mem_store=self.mem_store, ssl_context=sc)
         self.server._gc_interval = .1
         self.server.start()
 

--- a/object_database/frontends/database_server.py
+++ b/object_database/frontends/database_server.py
@@ -19,13 +19,17 @@ import sys
 import time
 import typed_python
 import object_database.tcp_server as tcp_server
+from util import sslContextFromCertPath
+
 from object_database.persistence import InMemoryPersistence, RedisPersistence
+
 
 def main(argv):
     parser = argparse.ArgumentParser("Run an object_database server")
 
     parser.add_argument("host")
     parser.add_argument("port", type=int)
+    parser.add_argument("ssl_path", help="path to (self-signed) SSL certificate")
     parser.add_argument("--redis_port", type=int, default=None)
     parser.add_argument("--inmem", default=False, action='store_true')
 
@@ -36,7 +40,13 @@ def main(argv):
     else:
         mem_store = RedisPersistence(port=parsedArgs.redis_port)
 
-    databaseServer = tcp_server.TcpServer(parsedArgs.host, parsedArgs.port, mem_store)
+    ssl_ctx = sslContextFromCertPath(parsedArgs.ssl_path)
+    databaseServer = tcp_server.TcpServer(
+        parsedArgs.host,
+        parsedArgs.port,
+        mem_store,
+        ssl_context=ssl_ctx
+    )
 
     databaseServer.start()
 

--- a/object_database/frontends/database_server.py
+++ b/object_database/frontends/database_server.py
@@ -19,7 +19,7 @@ import sys
 import time
 import typed_python
 import object_database.tcp_server as tcp_server
-from util import sslContextFromCertPath
+from object_database.util import sslContextFromCertPath
 
 from object_database.persistence import InMemoryPersistence, RedisPersistence
 

--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -45,7 +45,10 @@ def main(argv=None):
         try:
             server = subprocess.Popen(
                 [sys.executable, os.path.join(ownDir, '..', 'frontends', 'service_manager.py'),
-                    'localhost', 'localhost', "8020", "--run_db",'--source', os.path.join(tf,'source'),
+                    'localhost', 'localhost', "8020",
+                    os.path.join(ownDir, '..', '..', 'testcert.cert'),
+                    "--run_db",
+                    '--source', os.path.join(tf,'source'),
                     '--storage', os.path.join(tf,'storage'),
                     #'--logdir', os.path.join(tf,'logs'),
                     '--shutdownTimeout', '.5'

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -26,6 +26,7 @@ from object_database import connect
 from object_database.util import configureLogging
 from object_database.service_manager.ServiceWorker import ServiceWorker
 
+
 def main(argv):
     parser = argparse.ArgumentParser("Run a specific service.")
 

--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -89,7 +89,7 @@ def main(argv=None):
             databaseServer = TcpServer(
                 parsedArgs.own_hostname,
                 object_database_port,
-                RedisPersistence(port=parsedArgs.redis_port) or InMemoryPersistence(),
+                RedisPersistence(port=parsedArgs.redis_port) if parsedArgs.redis_port is not None else InMemoryPersistence(),
                 ssl_context=ssl_ctx
             )
 

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -33,6 +33,7 @@ import json
 
 DEFAULT_GC_INTERVAL = 900.0
 
+
 class ConnectedChannel:
     def __init__(self, initial_tid, channel, connectionObject, identityRoot):
         self.channel = channel
@@ -86,6 +87,7 @@ class ConnectedChannel:
 
     def extractTransactionData(self, guid):
         return self.pendingTransactions.pop(guid)
+
 
 class Server:
     def __init__(self, kvstore):


### PR DESCRIPTION
# Purpose
We want to use SSL to encrypt communications between the server and the workers (its clients). We only care about encrypting the communication, and not about making sure that the server authenticates with the clients. (This allows a man-in-the-middle attack, but we don't care about that at the moment).

# Approach
the `TcpServer()` object constructor now requires an SSL context. We create such an SSL context from a self-signed SSL cert. The `connect` method didn't need to change because, for the time being, we just want encryption and not authentication, therefore the clients generate a permissive SSL context which does not authenticate the server.

# Testing
All tests pass  