### PR TITLE
Tidy-up our logging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include object_database/web/content/*.css
 include object_database/web/content/*.html
 include object_database/service_manager/aws/*.sh
+include logging.yaml

--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ websockets = "*"
 llvmlite = "*"
 nativepython = {editable = true,path = "."}
 boto3 = "*"
+pyyaml = "*"
 
 [requires]
 python_version = "3.6.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "08355c92e706c80310ac17d5d4b89911b75cbbd64dd20c0121e3d1c320cbed70"
+            "sha256": "1dffb6a2dd42849d1948d39450506d9c2aa7d2a9fddd4d78e7fb731114598f51"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -324,6 +324,23 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2.7.5"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+            ],
+            "index": "pypi",
+            "version": "==3.13"
         },
         "redis": {
             "hashes": [

--- a/logging.yaml
+++ b/logging.yaml
@@ -7,7 +7,7 @@ formatters:
 handlers:
     default:
         class: logging.StreamHandler
-        level: DEBUG
+        level: INFO
         formatter: default
         stream: ext://sys.stdout
 

--- a/logging.yaml
+++ b/logging.yaml
@@ -1,0 +1,16 @@
+version: 1
+disable_existing_loggers: False
+formatters:
+    default:
+        format: '[%(asctime)s] %(levelname)8s %(filename)30s:%(lineno)4s | %(message)s'
+
+handlers:
+    default:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: default
+        stream: ext://sys.stdout
+
+root:
+    level: DEBUG
+    handlers: [default]

--- a/object_database/algebraic_protocol.py
+++ b/object_database/algebraic_protocol.py
@@ -25,6 +25,7 @@ class AlgebraicProtocol(asyncio.Protocol):
         self.transport = None
         self.buffer = bytes()
         self.writelock = threading.Lock()
+        self._logger = logging.getLogger(__name__)
 
     def sendMessage(self, msg):
         try:
@@ -41,7 +42,7 @@ class AlgebraicProtocol(asyncio.Protocol):
                     dataToSend = longToString(0) + dataToSend
                 self.transport.write(dataToSend)
         except:
-            logging.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
+            self._logger.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
             self.transport.close()
 
     def messageReceived(self, msg):
@@ -69,7 +70,7 @@ class AlgebraicProtocol(asyncio.Protocol):
                     try:
                         self.messageReceived(deserialize(self.receiveType, toConsume))
                     except:
-                        logging.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
+                        self._logger.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
                         self.transport.close()
             else:
                 return

--- a/object_database/database_ring_invariant_test.py
+++ b/object_database/database_ring_invariant_test.py
@@ -29,7 +29,7 @@ import threading
 
 from object_database.util import configureLogging
 
-configureLogging("test", error=True)
+configureLogging("test")
 
 schema = Schema("test_schema")
 

--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -46,7 +46,7 @@ def currentMemUsageMb(residentOnly=True):
         return psutil.Process().memory_info().vms / 1024 ** 2
 
 
-configureLogging("test", error=True)
+configureLogging("test")
 
 
 class BlockingCallback:
@@ -1499,6 +1499,11 @@ class ObjectDatabaseOverChannelTests(unittest.TestCase, ObjectDatabaseTests):
     def tearDown(self):
         self.server.stop()
 
+    def test_connection_without_auth_disconnects(self):
+        db = DatabaseConnection(self.server.getChannel())
+        with self.assertRaises(DisconnectedException):
+            db.subscribeToSchema(schema)
+
     def test_heartbeats(self):
         old_interval = messages.getHeartbeatInterval()
         messages.setHeartbeatInterval(.25)
@@ -1599,9 +1604,7 @@ class ObjectDatabaseOverSocketTests(unittest.TestCase, ObjectDatabaseTests):
 
     def createNewDb(self, useSecondaryLoop=False):
         db = self.server.connect(self.auth_token, useSecondaryLoop=useSecondaryLoop)
-
         db.initialized.wait()
-
         return db
 
     def tearDown(self):

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -16,7 +16,6 @@
 
 import argparse
 import logging
-import logging.config
 import sys
 import traceback
 
@@ -42,11 +41,13 @@ def main(argv):
 
     configureLogging(parsedArgs.instanceid[:8], error=parsedArgs.error_logs_only)
 
-    logging.info("service_entrypoint.py connecting to %s:%s for %s",
+    logger = logging.getLogger(__name__)
+
+    logger.info("service_entrypoint.py connecting to %s:%s for %s",
         parsedArgs.host,
         parsedArgs.port,
         parsedArgs.instanceid
-        )
+    )
 
     def dbConnectionFactory():
         return connect(parsedArgs.host, parsedArgs.port, parsedArgs.serviceToken)
@@ -63,7 +64,7 @@ def main(argv):
 
         return 0
     except Exception:
-        logging.error("service_entrypoint failed with an exception:\n%s", traceback.format_exc())
+        logger.error("service_entrypoint failed with an exception:\n%s", traceback.format_exc())
         return 1
 
 

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -35,11 +35,19 @@ def main(argv):
     parser.add_argument("sourceDir")
     parser.add_argument("storageRoot")
     parser.add_argument("serviceToken")
-    parser.add_argument("--error_logs_only", action='store_true', default=False)
+    parser.add_argument("--log-level", required=False, default="WARNING")
 
     parsedArgs = parser.parse_args(argv[1:])
 
-    configureLogging(parsedArgs.instanceid[:8], error=parsedArgs.error_logs_only)
+    validLogLevels = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+    level = parsedArgs.log_level.upper()
+    if level not in validLogLevels:
+        raise Exception(
+            "invalid --log-level value: %s. Must be one of %s"
+            % (level, validLogLevels)
+        )
+
+    configureLogging(preamble=parsedArgs.instanceid[:8], level=level)
 
     logger = logging.getLogger(__name__)
 

--- a/object_database/inmem_server.py
+++ b/object_database/inmem_server.py
@@ -27,6 +27,8 @@ class InMemoryChannel:
 
         self._stopHeartbeatingSet = False
 
+        self._logger =  logging.getLogger(__name__)
+
     def _stopHeartbeating(self):
         self._stopHeartbeatingSet = True
 
@@ -45,7 +47,7 @@ class InMemoryChannel:
                 try:
                     self._clientCallback(e)
                 except:
-                    logging.error("Pump thread failed for %s: %s", self, traceback.format_exc())
+                    self._logger.error("Pump thread failed for %s: %s", self, traceback.format_exc())
                     return
 
     def pumpMessagesFromClient(self):
@@ -65,7 +67,7 @@ class InMemoryChannel:
                     self._serverCallback(e)
                 except:
                     traceback.print_exc()
-                    logging.error("Pump thread failed: %s", traceback.format_exc())
+                    self._logger.error("Pump thread failed: %s", traceback.format_exc())
                     return
 
     def start(self):

--- a/object_database/persistence.py
+++ b/object_database/persistence.py
@@ -19,6 +19,7 @@ import threading
 import logging
 import os
 
+
 class InMemoryPersistence(object):
     def __init__(self, db=0):
         self.values = {}
@@ -135,6 +136,8 @@ class RedisPersistence(object):
         self.redis = redis.StrictRedis(db=db, decode_responses=True, **kwds)
         self.cache = {}
 
+        self._logger = logging.getLogger(__name__)
+
     def get(self, key):
         """Get the value stored in a value-style key, or None if no key exists.
 
@@ -151,7 +154,7 @@ class RedisPersistence(object):
                     result = self.redis.get(key)
                     success = True
                 except redis.exceptions.BusyLoadingError:
-                    logging.info("Redis is still loading. Waiting...")
+                    self._logger.info("Redis is still loading. Waiting...")
                     time.sleep(1.0)
 
             if result is None:
@@ -180,7 +183,7 @@ class RedisPersistence(object):
                         vals = self.redis.mget(needed_keys)
                         success = True
                     except redis.exceptions.BusyLoadingError:
-                        logging.info("Redis is still loading. Waiting...")
+                        self._logger.info("Redis is still loading. Waiting...")
                         time.sleep(1.0)
 
                 for ix in range(len(needed_keys)):
@@ -201,7 +204,7 @@ class RedisPersistence(object):
                     vals = self.redis.smembers(key)
                     success = True
                 except redis.exceptions.BusyLoadingError:
-                    logging.info("Redis is still loading. Waiting...")
+                    self._logger.info("Redis is still loading. Waiting...")
                     time.sleep(1.0)
 
             if vals:

--- a/object_database/service_manager/Codebase.py
+++ b/object_database/service_manager/Codebase.py
@@ -120,7 +120,7 @@ class Codebase:
                     if not os.path.exists(_codebase_instantiation_dir):
                         os.makedirs(_codebase_instantiation_dir)
                 except:
-                    logging.warn("Exception trying to make directory %s", _codebase_instantiation_dir)
+                    logging.getLogger(__name__).warn("Exception trying to make directory %s", _codebase_instantiation_dir)
 
                 disk_path = os.path.join(_codebase_instantiation_dir, self.hash)
 

--- a/object_database/service_manager/ServiceInstance.py
+++ b/object_database/service_manager/ServiceInstance.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 
 import importlib
-import logging
 import os
 import six
 import sys

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -48,6 +48,8 @@ class ServiceManager(object):
 
         self.SLEEP_INTERVAL = 0.5
 
+        self._logger = logging.getLogger(__name__)
+
     def start(self):
         self.thread.start()
 
@@ -152,7 +154,7 @@ class ServiceManager(object):
                 )
             self.serviceHostObject.hostname = self.ownHostname
 
-        logging.info("ServiceManager starting work loop.")
+        self._logger.info("ServiceManager starting work loop.")
 
         while not self.shouldStop.is_set():
             self.updateServiceHostStats()
@@ -176,7 +178,7 @@ class ServiceManager(object):
                     self.startServiceWorker(service, i._identity)
 
                 except Exception:
-                    logging.error("Failed to start a worker for instance %s:\n%s", i, traceback.format_exc())
+                    self._logger.error("Failed to start a worker for instance %s:\n%s", i, traceback.format_exc())
                     bad_instances[i] = traceback.format_exc()
 
             if bad_instances:
@@ -232,7 +234,7 @@ class ServiceManager(object):
                     needRedeploy.append(i)
 
             if needRedeploy:
-                logging.info(
+                self._logger.info(
                     "The following services need to be stopped because their codebases are out of date:\n%s",
                     "\n".join(["  " + i.service.name + "." + i._identity + ". "
                             + str(i.service.codebase) + " != " + str(i.codebase) for i in needRedeploy])

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -331,8 +331,8 @@ class ServiceManagerTest(unittest.TestCase):
                 [sys.executable, os.path.join(ownDir, '..', 'frontends', 'service_manager.py'),
                     'localhost', 'localhost', "8023",
                     "--run_db",
-                    '--source',os.path.join(self.tempDirectoryName,'source'),
-                    '--storage',os.path.join(self.tempDirectoryName,'storage'),
+                    '--source', os.path.join(self.tempDirectoryName, 'source'),
+                    '--storage', os.path.join(self.tempDirectoryName, 'storage'),
                     '--service-token', self.token,
                     '--shutdownTimeout', '1.0',
                     '--ssl-path', os.path.join(ownDir, '..', '..', 'testcert.cert')
@@ -418,7 +418,8 @@ class ServiceManagerTest(unittest.TestCase):
         numpy.random.seed(42)
 
         for count in numpy.random.choice(6, size=20):
-            logging.info("Setting count for TestService to %s and waiting for it to be alive.", count)
+            logging.getLogger(__name__).info(
+                "Setting count for TestService to %s and waiting for it to be alive.", count)
 
             with self.database.transaction():
                 ServiceManager.startService("TestService", int(count))

--- a/object_database/service_manager/ServiceWorker.py
+++ b/object_database/service_manager/ServiceWorker.py
@@ -30,6 +30,7 @@ import traceback
 
 class ServiceWorker:
     def __init__(self, dbConnectionFactory, instance_id, storageRoot, serviceToken):
+        self._logger = logging.getLogger(__name__)
         self.dbConnectionFactory = dbConnectionFactory
         self.db = dbConnectionFactory()
         self.db.subscribeToSchema(core_schema)
@@ -83,14 +84,14 @@ class ServiceWorker:
             try:
                 self.serviceObject = self._instantiateServiceObject()
             except:
-                logging.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
+                self._logger.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
                 self.instance.markFailedToStart(traceback.format_exc())
                 return
         try:
-            logging.info("Initializing service object for %s", self.instance._identity)
+            self._logger.info("Initializing service object for %s", self.instance._identity)
             self.serviceObject.initialize()
         except:
-            logging.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
+            self._logger.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
 
             self.serviceObject = None
 
@@ -118,10 +119,10 @@ class ServiceWorker:
             self.instance.state = "Running"
 
         try:
-            logging.info("Starting runloop for service object %s", self.instance._identity)
+            self._logger.info("Starting runloop for service object %s", self.instance._identity)
             self.serviceObject.doWork(self.shouldStop)
         except:
-            logging.error("Service %s/%s failed: %s",
+            self._logger.error("Service %s/%s failed: %s",
                 self.serviceName,
                 self.instance._identity,
                 traceback.format_exc()
@@ -134,7 +135,7 @@ class ServiceWorker:
                 return
         else:
             with self.db.transaction():
-                logging.info(
+                self._logger.info(
                     "Service %s/%s exited gracefully. Setting stopped flag.",
                     self.serviceName,
                     self.instance._identity

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -81,6 +81,7 @@ class SubprocessServiceManager(ServiceManager):
             maxGbRam=maxGbRam, maxCores=maxCores, shutdownTimeout=shutdownTimeout
         )
         self.serviceProcesses = {}
+        self._logger = logging.getLogger(__name__)
 
     def startServiceWorker(self, service, instanceIdentity):
         with self.db.view():
@@ -117,13 +118,13 @@ class SubprocessServiceManager(ServiceManager):
                     output_file.close()
 
             if self.logfileDirectory:
-                logging.info(
+                self._logger.info(
                     "Started a service logging to %s with pid %s",
                     os.path.join(self.logfileDirectory, logfileName),
                     process.pid
                     )
             else:
-                logging.info(
+                self._logger.info(
                     "Started service %s/%s with pid %s",
                     service.name,
                     instanceIdentity,
@@ -197,10 +198,10 @@ class SubprocessServiceManager(ServiceManager):
                         if file not in self.serviceProcesses:
                             try:
                                 path = os.path.join(self.storageDir, file)
-                                logging.info("Removing storage at path %s for dead service.", path)
+                                self._logger.info("Removing storage at path %s for dead service.", path)
                                 shutil.rmtree(path)
                             except:
-                                logging.error("Failed to remove storage at path %s for dead service:\n%s", path, traceback.format_exc())
+                                self._logger.error("Failed to remove storage at path %s for dead service:\n%s", path, traceback.format_exc())
 
         if self.sourceDir:
             with self.lock:
@@ -209,10 +210,10 @@ class SubprocessServiceManager(ServiceManager):
                         if file not in self.serviceProcesses:
                             try:
                                 path = os.path.join(self.sourceDir, file)
-                                logging.info("Removing source caches at path %s for dead service.", path)
+                                self._logger.info("Removing source caches at path %s for dead service.", path)
                                 shutil.rmtree(path)
                             except:
-                                logging.error("Failed to remove source cache at path %s for dead service:\n%s", path, traceback.format_exc())
+                                self._logger.error("Failed to remove source cache at path %s for dead service:\n%s", path, traceback.format_exc())
 
 
 

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -105,7 +105,7 @@ class SubprocessServiceManager(ServiceManager):
                         os.path.join(self.sourceDir, instanceIdentity),
                         os.path.join(self.storageDir, instanceIdentity),
                         self.serviceToken
-                        ] + (["--error_logs_only"] if self.errorLogsOnly else []),
+                        ] + (['--log-level', 'ERROR'] if self.errorLogsOnly else []),
                     cwd=self.storageDir,
                     stdin=subprocess.DEVNULL,
                     stdout=output_file,

--- a/object_database/tcp_server.py
+++ b/object_database/tcp_server.py
@@ -21,13 +21,14 @@ class ServerToClientProtocol(AlgebraicProtocol):
         self.dbserver = dbserver
         self.loop = loop
         self.connectionIsDead = False
+        self._logger = logging.getLogger(__name__)
 
     def setClientToServerHandler(self, handler):
         def callHandler(*args):
             try:
                 return handler(*args)
             except:
-                logging.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
+                self._logger.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
 
         self.handler = callHandler
 
@@ -64,6 +65,7 @@ class ClientToServerProtocol(AlgebraicProtocol):
         self.msgs = []
         self.disconnected = False
         self._stopHeartbeatingSet = False
+        self._logger = logging.getLogger(__name__)
 
     def _stopHeartbeating(self):
         self._stopHeartbeatingSet = True
@@ -74,7 +76,7 @@ class ClientToServerProtocol(AlgebraicProtocol):
                 try:
                     return handler(*args)
                 except Exception:
-                    logging.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
+                    self._logger.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
 
             self.handler = callHandler
             for m in self.msgs:

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -75,13 +75,12 @@ def setupLogging(
         logging.basicConfig(level=default_level)
 
 
-def configureLogging(preamble="", error=False):
+def configureLogging(preamble="", level=logging.INFO):
     frmt = (
         '[%(asctime)s] %(levelname)8s %(filename)30s:%(lineno)4s | ' +
         (preamble + ' | ' if preamble else '') +
         '%(message)s'
     )
-    level = logging.INFO if not error else logging.ERROR
 
     updates = {
         'formatters': {

--- a/object_database/view.py
+++ b/object_database/view.py
@@ -26,16 +26,20 @@ import traceback
 
 LOG_SLOW_COMMIT_THRESHOLD = 1.0
 
+
 class DisconnectedException(Exception):
     pass
 
+
 class RevisionConflictException(Exception):
     pass
+
 
 class ObjectDoesntExistException(Exception):
     def __init__(self, obj):
         super().__init__("%s(%s)" % (type(obj).__qualname__, obj._identity))
         self.obj = obj
+
 
 def revisionConflictRetry(f):
     MAX_TRIES = 100
@@ -55,6 +59,7 @@ def revisionConflictRetry(f):
 
     inner.__name__ = f.__name__
     return inner
+
 
 class SerializedDatabaseValue:
     """A value stored as Json with a python representation."""
@@ -78,7 +83,9 @@ def coerce_value(value, toType):
 def default_initialize(t):
     return t()
 
+
 _cur_view = threading.local()
+
 
 class View(object):
     _writeable = False
@@ -487,6 +494,7 @@ class View(object):
         finally:
             self._db._releaseView(self)
 
+
 class Transaction(View):
     _writeable = True
 
@@ -530,6 +538,7 @@ class Transaction(View):
         self._confirmCommitCallback = ignoreConfirmResult
 
         return self
+
 
 def current_transaction():
     if not hasattr(_cur_view, "view"):

--- a/object_database/view.py
+++ b/object_database/view.py
@@ -46,7 +46,9 @@ def revisionConflictRetry(f):
             try:
                 return f(*args, **kwargs)
             except RevisionConflictException as e:
-                logging.info("Handled a revision conflict on key %s in %s. Retrying." % (e, f.__name__))
+                logging.getLogger(__name__).info(
+                    "Handled a revision conflict on key %s in %s. Retrying." % (e, f.__name__)
+                )
                 tries += 1
 
         raise RevisionConflictException()
@@ -97,6 +99,7 @@ class View(object):
         self._insistWritesConsistent = True
         self._insistIndexReadsConsistent = False
         self._confirmCommitCallback = None
+        self._logger = logging.getLogger(__name__)
 
     def db(self):
         return self._db
@@ -446,7 +449,7 @@ class View(object):
                 res = result_queue.get()
 
                 if time.time() - t0 > LOG_SLOW_COMMIT_THRESHOLD:
-                    logging.info("Committing %s writes and %s set changes took %.1f seconds",
+                    self._logger.info("Committing %s writes and %s set changes took %.1f seconds",
                         len(self._writes), len(self._set_adds) + len(self._set_removes), time.time() - t0
                         )
 

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -99,6 +99,8 @@ class Cells:
 
         self.db._onTransaction.append(self._onTransaction)
 
+        self._logger = logging.getLogger(__name__)
+
     def _newID(self):
         self._id += 1
         return str(self._id)
@@ -213,8 +215,8 @@ class Cells:
                         except SubscribeAndRetry as e:
                             e.callback(self.db)
                 except:
-                    logging.error("Node %s had exception during recalculation:\n%s", n, traceback.format_exc())
-                    logging.error("Subscribed cell threw an exception:\n%s", traceback.format_exc())
+                    self._logger.error("Node %s had exception during recalculation:\n%s", n, traceback.format_exc())
+                    self._logger.error("Subscribed cell threw an exception:\n%s", traceback.format_exc())
                     n.children = {'____contents__': Traceback(traceback.format_exc())}
 
                 finally:
@@ -687,10 +689,10 @@ class Dropdown(Cell):
             except RevisionConflictException as e:
                 tries += 1
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
-                    logging.error("Button click timed out. This should really fail.")
+                    self._logger.error("Button click timed out. This should really fail.")
                     return
             except:
-                logging.error("Exception in button logic:\n%s", traceback.format_exc())
+                self._logger.error("Exception in button logic:\n%s", traceback.format_exc())
                 return
 
 class Container(Cell):
@@ -805,7 +807,7 @@ class SubscribedSequence(Cell):
             except SubscribeAndRetry:
                 raise
             except:
-                logging.error("Spine calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error("Spine calc threw an exception:\n%s", traceback.format_exc())
                 self.spine = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -894,14 +896,14 @@ class Grid(Cell):
             except SubscribeAndRetry:
                 raise
             except:
-                logging.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
                 self.rows = []
             try:
                 self.cols = list(self.colFun())
             except SubscribeAndRetry:
                 raise
             except:
-                logging.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
                 self.cols = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -1102,7 +1104,7 @@ class Table(Cell):
                         r = self.cachedRenderFun(row, col)
                         keymemo[row] = SortWrapper(r.sortsAs())
                     except:
-                        logging.error(traceback.format_exc())
+                        self._logger.error(traceback.format_exc())
                         keymemo[row] = SortWrapper(None)
 
                 return keymemo[row]
@@ -1117,7 +1119,7 @@ class Table(Cell):
             page = max(0, int(self.curPage.get())-1)
             page = min(page, (len(rows) - 1) // self.maxRowsPerPage)
         except:
-            logging.error("Failed to parse current page: %s", traceback.format_exc())
+            self._logger.error("Failed to parse current page: %s", traceback.format_exc())
 
         return rows[page * self.maxRowsPerPage:(page+1) * self.maxRowsPerPage]
 
@@ -1157,7 +1159,7 @@ class Table(Cell):
             except SubscribeAndRetry:
                 raise
             except:
-                logging.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
                 self.cols = []
 
             try:
@@ -1168,7 +1170,7 @@ class Table(Cell):
             except SubscribeAndRetry:
                 raise
             except:
-                logging.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
                 self.rows = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -1290,10 +1292,10 @@ class Clickable(Cell):
             except RevisionConflictException as e:
                 tries += 1
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
-                    logging.error("Button click timed out. This should really fail.")
+                    self._logger.error("Button click timed out. This should really fail.")
                     return
             except:
-                logging.error("Exception in button logic:\n%s", traceback.format_exc())
+                self._logger.error("Exception in button logic:\n%s", traceback.format_exc())
                 return
 
 class Button(Clickable):
@@ -1522,7 +1524,7 @@ class _PlotUpdater(Cell):
             except SubscribeAndRetry:
                 raise
             except:
-                logging.error(traceback.format_exc())
+                self._logger.error(traceback.format_exc())
                 self.contents = """<div>____contents__</div>"""
                 self.children = {'____contents__': Traceback(traceback.format_exc())}
 

--- a/test.py
+++ b/test.py
@@ -36,6 +36,10 @@ import subprocess
 import pickle
 import hashlib
 
+from object_database.util import setupLogging
+
+setupLogging()
+logger = logging.getLogger(__name__)
 
 class DirectoryScope(object):
     def __init__(self, directory):
@@ -59,11 +63,11 @@ def loadTestModules(testFiles, rootDir):
         try:
             with DirectoryScope(rootDir):
                 moduleName = fileNameToModuleName(f, rootDir)
-                logging.info('importing module %s', moduleName)
+                logger.debug('importing module %s', moduleName)
                 __import__(moduleName)
                 modules.add(sys.modules[moduleName])
         except ImportError:
-            logging.error("Failed to load test module: %s", moduleName)
+            logger.error("Failed to load test module: %s", moduleName)
             traceback.print_exc()
             raise
 
@@ -243,7 +247,7 @@ def loadTestCases(config, testFiles, rootDir):
 
 
 def findTestFiles(rootDir, testRegex):
-    logging.info('finding files from root %s', rootDir)
+    logger.debug('finding files from root %s', rootDir)
     testPattern = re.compile(testRegex)
     testFiles = []
     for directory, subdirectories, files in os.walk(rootDir):
@@ -260,8 +264,8 @@ def logAsInfo(*args):
 
 
 def setLoggingLevel(level):
-    logging.getLogger().setLevel(level)
-    for handler in logging.getLogger().handlers:
+    logger.setLevel(level)
+    for handler in logger.handlers:
         handler.setLevel(level)
 
 
@@ -568,7 +572,7 @@ def main(args):
         return executeTests(args, filter_actions)
     except:
         import traceback
-        logging.error("executeTests() threw an exception: \n%s", traceback.format_exc())
+        logger.error("executeTests() threw an exception: \n%s", traceback.format_exc())
         return 1
 
 

--- a/test.py
+++ b/test.py
@@ -38,7 +38,7 @@ import hashlib
 
 from object_database.util import setupLogging
 
-setupLogging()
+setupLogging('logging.yaml')
 logger = logging.getLogger(__name__)
 
 class DirectoryScope(object):

--- a/typed_python/Codebase.py
+++ b/typed_python/Codebase.py
@@ -155,7 +155,8 @@ class Codebase:
             try:
                 modules[mname] = importlib.import_module(mname)
             except Exception as e:
-                logging.warn("Error importing module %s from codebase: %s", mname,  e)
+                logging.getLogger(__name__).warn(
+                    "Error importing module %s from codebase: %s", mname,  e)
         return modules
 
     @staticmethod


### PR DESCRIPTION
1. Use `self._logger = logging.getLogger(__name__)` to get a file-specific logger for finer control
2. Use `logging.config.dictConfig(...)` instead of `logging.basicConfig(...)` to configure how logging will look. This is more robust and a lot of the configuration can live in the config file (i.e., not in code), but we can still modify configs on the fly as is done in object_database.util::configureLogging