### PR TITLE
SerializationContext fixups

### DIFF
--- a/typed_python/SerializationContext.py
+++ b/typed_python/SerializationContext.py
@@ -66,7 +66,7 @@ class SerializationContext(object):
         tid = id(t)
         res = self.objToName.get(tid)
 
-        if res:
+        if res is not None:
             return res
         else:
             return _builtin_value_to_name.get(tid)
@@ -75,7 +75,7 @@ class SerializationContext(object):
         ''' Return an object for an input name(string), or None if not found. '''
         res = self.nameToObject.get(name)
 
-        if res:
+        if res is not None:
             return res
         else:
             return _builtin_name_to_value.get(name)

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -261,3 +261,10 @@ class TypesSerializationTest(unittest.TestCase):
         self.assertTrue(ts.serialize(X(x=20)) != ts.serialize(X(x=21)))
 
         self.check_idempotence(ts, X(x=20))
+
+    def test_bad_serialization_context(self):
+        with self.assertRaises(AssertionError):
+            ts = SerializationContext({'': int})
+
+        with self.assertRaises(AssertionError):
+            ts = SerializationContext({b'': int})

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -268,3 +268,13 @@ class TypesSerializationTest(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             ts = SerializationContext({b'': int})
+
+    def test_serialization_context_queries(self):
+        sc = SerializationContext({
+            'X': False,
+            'Y': True,
+        })
+        self.assertIs(sc.objectFromName('X'), False)
+        self.assertIs(sc.nameFromObject(False), 'X')
+        self.assertIs(sc.objectFromName('Y'), True)
+        self.assertIs(sc.nameFromObject(True), 'Y')


### PR DESCRIPTION
1. Assert that we are not initializing the context with an empty name
2. Assert that the names are strings
3. Query the user-defined names before the `builtins`. This should not matter because we the builtin names start with a dot (.), but it is still preferable.