### PR TITLE
Members with default values

### DIFF
--- a/typed_python/Instance.hpp
+++ b/typed_python/Instance.hpp
@@ -47,6 +47,18 @@ public:
         });
     }
 
+    static Instance create(bool val) {
+        return create(Bool::Make(), (instance_ptr)&val);
+    }
+
+    static Instance create(long val) {
+        return create(Int64::Make(), (instance_ptr)&val);
+    }
+
+    static Instance create(double val) {
+        return create(Float64::Make(), (instance_ptr)&val);
+    }
+
     static Instance create(Type*t, instance_ptr data) {
         t->assertForwardsResolved();
 
@@ -61,7 +73,7 @@ public:
     }
 
     Instance() {
-        //by default, None
+        // by default, None
         mLayout = noneLayout();
         mLayout->refcount++;
     }

--- a/typed_python/Type.cpp
+++ b/typed_python/Type.cpp
@@ -1714,8 +1714,8 @@ void HeldClass::_forwardTypesMayHaveChanged() {
     m_is_default_constructible = true;
     m_byte_offsets.clear();
 
-    //first m_members.size() bits (rounded to nearest byte) contains the initialization flags.
-    m_size = int((m_members.size()) / 8) + 1; //round up to nearest byte
+    //first m_members.size() bits (rounded up to nearest byte) contains the initialization flags.
+    m_size = int((m_members.size() + 7) / 8); //round up to nearest byte
 
     for (auto t: m_members) {
         m_byte_offsets.push_back(m_size);
@@ -1814,11 +1814,14 @@ void HeldClass::constructor(instance_ptr self) {
     for (size_t k = 0; k < m_members.size(); k++) {
         Type* member_t = std::get<1>(m_members[k]);
         PyObject* member_val = std::get<2>(m_members[k]);
+        Type* valType = native_instance_wrapper::extractTypeFrom(member_val->ob_type);
         if (wantsToDefaultConstruct(member_t)) {
             if (member_val != Py_None) {
                 std::cout << "blabla!" << std::endl;
-	        }
-            member_t->constructor(self+m_byte_offsets[k]);
+
+	        } else {
+                member_t->constructor(self+m_byte_offsets[k]);
+            }
             setInitializationFlag(self, k);
         } else {
             clearInitializationFlag(self, k);

--- a/typed_python/Type.cpp
+++ b/typed_python/Type.cpp
@@ -1813,12 +1813,12 @@ void HeldClass::emptyConstructor(instance_ptr self) {
 void HeldClass::constructor(instance_ptr self) {
     for (size_t k = 0; k < m_members.size(); k++) {
         Type* member_t = std::get<1>(m_members[k]);
-        PyObject* member_val = std::get<2>(m_members[k]);
-        Type* valType = native_instance_wrapper::extractTypeFrom(member_val->ob_type);
-        if (wantsToDefaultConstruct(member_t)) {
-            if (member_val != Py_None) {
-                std::cout << "blabla!" << std::endl;
+        Instance& member_val = std::get<2>(m_members[k]);
 
+        if (wantsToDefaultConstruct(member_t)) {
+            if (member_val.type() != None::Make()) {
+                std::cout << "blabla!" << std::endl;
+                member_t->copy_constructor(self+m_byte_offsets[k], member_val.data());
 	        } else {
                 member_t->constructor(self+m_byte_offsets[k]);
             }

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -1938,7 +1938,7 @@ private:
 class HeldClass : public Type {
 public:
     HeldClass(std::string inName,
-          const std::vector<std::pair<std::string, Type*> >& members,
+          const std::vector<std::tuple<std::string, Type*, PyObject*> >& members,
           const std::map<std::string, Function*>& memberFunctions,
           const std::map<std::string, Function*>& staticFunctions,
           const std::map<std::string, PyObject*>& classMembers
@@ -2091,12 +2091,13 @@ public:
 private:
     std::vector<size_t> m_byte_offsets;
 
-    std::vector<std::pair<std::string, Type*> > m_members;
+    std::vector<std::tuple<std::string, Type*, PyObject*> > m_members;
 
     std::map<std::string, Function*> m_memberFunctions;
     std::map<std::string, Function*> m_staticFunctions;
     std::map<std::string, PyObject*> m_classMembers;
 };
+
 
 class Class : public Type {
     class layout {
@@ -2134,7 +2135,7 @@ public:
 
     static Class* Make(
             std::string inName,
-            const std::vector<std::pair<std::string, Type*> >& members,
+            const std::vector<std::tuple<std::string, Type*, PyObject*> >& members,
             const std::map<std::string, Function*>& memberFunctions,
             const std::map<std::string, Function*>& staticFunctions,
             const std::map<std::string, PyObject*>& classMembers

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -1146,15 +1146,6 @@ public:
 
 class Value : public Type {
 public:
-    Value(Instance instance) :
-            Type(TypeCategory::catValue),
-            mInstance(instance)
-    {
-        m_size = 0;
-        m_is_default_constructible = true;
-        m_name = mInstance.repr();
-    }
-
     bool isBinaryCompatibleWithConcrete(Type* other) {
         return this == other;
     }
@@ -1241,6 +1232,15 @@ public:
     }
 
 private:
+    Value(Instance instance) :
+            Type(TypeCategory::catValue),
+            mInstance(instance)
+    {
+        m_size = 0;
+        m_is_default_constructible = true;
+        m_name = mInstance.repr();
+    }
+
     Instance mInstance;
 };
 

--- a/typed_python/Type.hpp
+++ b/typed_python/Type.hpp
@@ -1939,7 +1939,7 @@ private:
 class HeldClass : public Type {
 public:
     HeldClass(std::string inName,
-          const std::vector<std::tuple<std::string, Type*, PyObject*> >& members,
+          const std::vector<std::tuple<std::string, Type*, Instance> >& members,
           const std::map<std::string, Function*>& memberFunctions,
           const std::map<std::string, Function*>& staticFunctions,
           const std::map<std::string, PyObject*>& classMembers
@@ -1984,7 +1984,7 @@ public:
 
     static HeldClass* Make(
             std::string inName,
-            const std::vector<std::tuple<std::string, Type*, PyObject*> >& members,
+            const std::vector<std::tuple<std::string, Type*, Instance> >& members,
             const std::map<std::string, Function*>& memberFunctions,
             const std::map<std::string, Function*>& staticFunctions,
             const std::map<std::string, PyObject*>& classMembers
@@ -2077,7 +2077,7 @@ public:
         return std::get<0>(m_members[index]);
     }
 
-    const std::vector<std::tuple<std::string, Type*, PyObject*> >& getMembers() const {
+    const std::vector<std::tuple<std::string, Type*, Instance> >& getMembers() const {
         return m_members;
     }
 
@@ -2102,7 +2102,7 @@ public:
 private:
     std::vector<size_t> m_byte_offsets;
 
-    std::vector<std::tuple<std::string, Type*, PyObject*> > m_members;
+    std::vector<std::tuple<std::string, Type*, Instance> > m_members;
 
     std::map<std::string, Function*> m_memberFunctions;
     std::map<std::string, Function*> m_staticFunctions;
@@ -2146,7 +2146,7 @@ public:
 
     static Class* Make(
             std::string inName,
-            const std::vector<std::tuple<std::string, Type*, PyObject*> >& members,
+            const std::vector<std::tuple<std::string, Type*, Instance> >& members,
             const std::map<std::string, Function*>& memberFunctions,
             const std::map<std::string, Function*>& staticFunctions,
             const std::map<std::string, PyObject*>& classMembers
@@ -2218,7 +2218,7 @@ public:
         return m_heldClass->getMemberName(index);
     }
 
-    const std::vector<std::tuple<std::string, Type*, PyObject*> >& getMembers() const {
+    const std::vector<std::tuple<std::string, Type*, Instance> >& getMembers() const {
         return m_heldClass->getMembers();
     }
 

--- a/typed_python/_types.cc
+++ b/typed_python/_types.cc
@@ -342,7 +342,7 @@ bool unpackTupleToStringTypesAndValues(PyObject* tuple, std::vector<std::tuple<s
 
         memberNames.insert(memberName);
 
-        Instance inst = native_instance_wrapper::tryUnwrapPyObjectToInstance(PyTuple_GetItem(entry, 2));
+        Instance inst = native_instance_wrapper::unwrapPyObjectToInstance(PyTuple_GetItem(entry, 2));
 
         if (PyErr_Occurred()) {
             return false;
@@ -672,11 +672,11 @@ PyObject *refcount(PyObject* nullValue, PyObject* args) {
 
     Type* actualType = native_instance_wrapper::extractTypeFrom(a1->ob_type);
 
-    if (!actualType ||
+    if (!actualType || (
             actualType->getTypeCategory() != Type::TypeCategory::catTupleOf &&
             actualType->getTypeCategory() != Type::TypeCategory::catClass &&
             actualType->getTypeCategory() != Type::TypeCategory::catConstDict
-            ) {
+            )) {
         PyErr_Format(
             PyExc_TypeError,
             "first argument to refcount must be one of ConstDict, TupleOf, or Class, not %S",

--- a/typed_python/_types.cc
+++ b/typed_python/_types.cc
@@ -555,7 +555,7 @@ PyObject *MakeClassType(PyObject* nullValue, PyObject* args) {
         return NULL;
     }
 
-    std::vector<std::pair<std::string, Type*> > members;
+    std::vector<std::tuple<std::string, Type*, PyObject*> > members;
     std::vector<std::pair<std::string, Type*> > memberFunctions;
     std::vector<std::pair<std::string, Type*> > staticFunctions;
     std::vector<std::pair<std::string, PyObject*> > classMembers;

--- a/typed_python/class_types_test.py
+++ b/typed_python/class_types_test.py
@@ -21,6 +21,22 @@ from typed_python import (
     Alternative, serialize, deserialize, Value, Class, Member, _types
 )
 
+class DefaultVal(Class):
+    x0 = Member(int)
+    x1 = Member(int, 5)
+
+    y0 = Member(bool)
+    y1 = Member(bool, True)
+
+    z0 = Member(float)
+    z1 = Member(float, 3.14)
+
+    b0 = Member(bytes)
+    b1 = Member(bytes, b"abc")
+
+    s0 = Member(str)
+    s1 = Member(str, "abc")
+
 
 class Interior(Class):
     x = Member(int)
@@ -62,6 +78,24 @@ class ClassWithComplexDispatch(Class):
         return 'y'
 
 class NativeClassTypesTests(unittest.TestCase):
+    def test_member_default_value(self):
+        c = DefaultVal()
+
+        self.assertEqual(c.x0, 0)
+        self.assertEqual(c.x1, 5)
+
+        self.assertEqual(c.y0, False)
+        self.assertEqual(c.y1, True)
+
+        self.assertEqual(c.z0, 0.0)
+        self.assertEqual(c.z1, 3.14)
+
+        self.assertEqual(c.b0, b"")
+        self.assertEqual(c.b1, b"abc")
+
+        self.assertEqual(c.s0, "")
+        self.assertEqual(c.s1, "abc")
+
     def test_class_dispatch_by_name(self):
         c = ClassWithComplexDispatch(x=200)
 

--- a/typed_python/internals.py
+++ b/typed_python/internals.py
@@ -43,8 +43,11 @@ def forwardToName(fwdLambda):
     return "UnknownForward"
 
 class Member:
-    def __init__(self, t):
+    def __init__(self, t, default_value=None):
         self.t = t
+        self.v = default_value
+        if self.v is not None:
+            assert isinstance(self.v, self.t)
 
     def __eq__(self, other):
         if not isinstance(other, Member):
@@ -126,7 +129,7 @@ class ClassMetaclass(type):
 
         for eltName, elt in namespace.order:
             if isinstance(elt, Member):
-                members.append((eltName, elt.t))
+                members.append((eltName, elt.t, elt.v))
                 classMembers.append((eltName, elt))
             elif isinstance(elt, staticmethod):
                 if eltName not in staticFunctions:

--- a/typed_python/native_instance_wrapper.cc
+++ b/typed_python/native_instance_wrapper.cc
@@ -875,13 +875,13 @@ PyObject* native_instance_wrapper::tp_new(PyTypeObject *subtype, PyObject *args,
             return NULL;
         }
 
-        //not reachable
+        // not reachable
         assert(false);
 
     } else {
         instance_ptr tgt = (instance_ptr)malloc(eltType->bytecount());
 
-        try{
+        try {
             constructFromPythonArguments(tgt, eltType, args, kwds);
         } catch(std::exception& e) {
             free(tgt);

--- a/typed_python/native_instance_wrapper.h
+++ b/typed_python/native_instance_wrapper.h
@@ -183,7 +183,7 @@ struct native_instance_wrapper {
 
     static PyObject* categoryToPyString(Type::TypeCategory cat);
 
-    static Instance tryUnwrapPyObjectToInstance(PyObject* inst);
+    static Instance unwrapPyObjectToInstance(PyObject* inst);
 
     static Type* tryUnwrapPyInstanceToValueType(PyObject* typearg);
 

--- a/typed_python/native_instance_wrapper.h
+++ b/typed_python/native_instance_wrapper.h
@@ -130,7 +130,7 @@ struct native_instance_wrapper {
 
     static bool isSubclassOfNativeType(PyTypeObject* typeObj);
 
-    static bool isTypedPythonType(PyTypeObject* typeObj);
+    static bool isNativeType(PyTypeObject* typeObj);
 
     static Type* extractTypeFrom(PyTypeObject* typeObj, bool exact=false);
 

--- a/typed_python/native_instance_wrapper.h
+++ b/typed_python/native_instance_wrapper.h
@@ -183,6 +183,8 @@ struct native_instance_wrapper {
 
     static PyObject* categoryToPyString(Type::TypeCategory cat);
 
+    static Instance tryUnwrapPyObjectToInstance(PyObject* inst);
+
     static Type* tryUnwrapPyInstanceToValueType(PyObject* typearg);
 
     static PyObject* typePtrToPyTypeRepresentation(Type* t);


### PR DESCRIPTION
# Purpose 
To allow us doing things like this:
```
class MyClass(Class):
    x = Member(float, 3.14)
    y = Message(str, "Here be dragons")
```

# Approach
`HeldClass` holds an `Instance` along with each member `Type` and we unwrap `PyObject*` that comes from the python side to an `Instance` object on the C side.

# Questions
- `native_instance_wrapper::tryUnwrapPyObjectToInstance` should probably be `static Instance Instance::create(PyObject* o)` , right?

# Notes
- Renamed `isTypedPythonType`  to `isNativeType` to follow more closely the naming style of the rest of the code.