### PR TITLE
Replace "exception:" with "exception Exception:"

### DIFF
--- a/nativepython/llvm_compiler.py
+++ b/nativepython/llvm_compiler.py
@@ -107,7 +107,7 @@ class Compiler:
         try:
             mod = llvm.parse_assembly(module)
             mod.verify()
-        except:
+        except Exception:
             print("failing: ", module)
             raise
 

--- a/nativepython/native_ast_to_llvm.py
+++ b/nativepython/native_ast_to_llvm.py
@@ -965,7 +965,7 @@ class FunctionConverter:
                     self.builder.position_at_start(normal_target)
                 else:
                     llvm_call_result = self.builder.call(func.llvm_value, [a.llvm_value for a in args])
-            except:
+            except Exception:
                 print("failing while calling ", target.name)
                 for a in args:
                     print("\t", a.llvm_value, a.native_type)

--- a/nativepython/tests/arithmetic_compilation_test.py
+++ b/nativepython/tests/arithmetic_compilation_test.py
@@ -100,12 +100,12 @@ class TestArithmeticCompilation(unittest.TestCase):
                 for val2 in rvals:
                     try:
                         pyVal = f(val1,val2)
-                    except:
+                    except Exception:
                         pyVal = "Exception"
 
                     try:
                         llvmVal = f_fast(val1,val2)
-                    except:
+                    except Exception:
                         llvmVal = "Exception"
 
                     if type(pyVal) is not type(llvmVal) or pyVal != llvmVal:

--- a/object_database/algebraic_protocol.py
+++ b/object_database/algebraic_protocol.py
@@ -36,7 +36,7 @@ class AlgebraicProtocol(asyncio.Protocol):
 
             with self.writelock:
                 self.transport.write(dataToSend)
-        except:
+        except Exception:
             self._logger.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
             self.transport.close()
 
@@ -65,7 +65,7 @@ class AlgebraicProtocol(asyncio.Protocol):
                 if toConsume:
                     try:
                         self.messageReceived(deserialize(self.receiveType, toConsume))
-                    except:
+                    except Exception:
                         self._logger.error("Error in AlgebraicProtocol: %s", traceback.format_exc())
                         self.transport.close()
             else:

--- a/object_database/database_connection.py
+++ b/object_database/database_connection.py
@@ -402,7 +402,7 @@ class TransactionListener:
             if todo:
                 try:
                     self.handler(todo)
-                except:
+                except Exception:
                     logger.error("Callback threw exception:\n%s", traceback.format_exc())
 
 
@@ -656,7 +656,7 @@ class DatabaseConnection:
                 try:
                     if cond():
                         return True
-                except:
+                except Exception:
                     self._logger.error("Condition callback threw an exception:\n%s", traceback.format_exc())
 
                 time.sleep(min(timeout / 20, .25))
@@ -771,7 +771,7 @@ class DatabaseConnection:
                 for q in self._transaction_callbacks.values():
                     try:
                         q(TransactionResult.Disconnected())
-                    except:
+                    except Exception:
                         self._logger.error(
                             "Transaction commit callback threw an exception:\n%s",
                             traceback.format_exc()
@@ -799,7 +799,7 @@ class DatabaseConnection:
                         TransactionResult.Success() if msg.success
                             else TransactionResult.RevisionConflict(key=msg.badKey)
                         )
-                except:
+                except Exception:
                     self._logger.error(
                         "Transaction commit callback threw an exception:\n%s",
                         traceback.format_exc()
@@ -838,7 +838,7 @@ class DatabaseConnection:
             for handler in self._onTransaction:
                 try:
                     handler(key_value, priors, set_adds, set_removes, msg.transaction_id)
-                except:
+                except Exception:
                     self._logger.error(
                         "_onTransaction callback %s threw an exception:\n%s",
                         handler,

--- a/object_database/frontends/aws_config.py
+++ b/object_database/frontends/aws_config.py
@@ -158,7 +158,7 @@ def main(argv):
             for i in api.allRunningInstances():
                 try:
                     api.terminateInstanceById(i)
-                except:
+                except Exception:
                     pass
 
     return 0

--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -147,7 +147,7 @@ def main(argv=None):
                         logger.error("Disconnected from object_database host. Attempting to reconnect.")
                         serviceManager.stop(gracefully=False)
                         serviceManager = None
-                    except:
+                    except Exception:
                         logger.error("Service manager cleanup failed:\n%s", traceback.format_exc())
         except KeyboardInterrupt:
             return 0
@@ -157,13 +157,13 @@ def main(argv=None):
         if serviceManager is not None:
             try:
                 serviceManager.stop(gracefully=False)
-            except:
+            except Exception:
                 logger.error("Failed to stop the service manager:\n%s", traceback.format_exc())
 
         if databaseServer is not None:
             try:
                 databaseServer.stop()
-            except:
+            except Exception:
                 logger.error("Failed to stop the database server:\n%s", traceback.format_exc())
 
 

--- a/object_database/inmem_server.py
+++ b/object_database/inmem_server.py
@@ -46,7 +46,7 @@ class InMemoryChannel:
             if e:
                 try:
                     self._clientCallback(e)
-                except:
+                except Exception:
                     self._logger.error("Pump thread failed for %s: %s", self, traceback.format_exc())
                     return
 
@@ -65,7 +65,7 @@ class InMemoryChannel:
             if e:
                 try:
                     self._serverCallback(e)
-                except:
+                except Exception:
                     traceback.print_exc()
                     self._logger.error("Pump thread failed: %s", traceback.format_exc())
                     return

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -197,7 +197,7 @@ class Server:
                         self.handleSubscriptionOnBackgroundThread(connectedChannel, msg)
                 except queue.Empty:
                     pass
-            except:
+            except Exception:
                 self._logger.error("Unexpected error in serviceSubscription thread:\n%s", traceback.format_exc())
 
 

--- a/object_database/service_manager/Codebase.py
+++ b/object_database/service_manager/Codebase.py
@@ -122,7 +122,7 @@ class Codebase:
                 try:
                     if not os.path.exists(_codebase_instantiation_dir):
                         os.makedirs(_codebase_instantiation_dir)
-                except:
+                except Exception:
                     logging.getLogger(__name__).warn("Exception trying to make directory %s", _codebase_instantiation_dir)
 
                 disk_path = os.path.join(_codebase_instantiation_dir, self.hash)

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -355,7 +355,7 @@ class ServiceManagerTest(unittest.TestCase):
         try:
             self.database = connect("localhost", 8023, self.token, retry=True)
             self.database.subscribeToSchema(core_schema, service_schema, schema)
-        except:
+        except Exception:
             self.server.terminate()
             self.server.wait()
             self.tempDirObj.__exit__(None,None,None)

--- a/object_database/service_manager/ServiceWorker.py
+++ b/object_database/service_manager/ServiceWorker.py
@@ -83,14 +83,14 @@ class ServiceWorker:
 
             try:
                 self.serviceObject = self._instantiateServiceObject()
-            except:
+            except Exception:
                 self._logger.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
                 self.instance.markFailedToStart(traceback.format_exc())
                 return
         try:
             self._logger.info("Initializing service object for %s", self.instance._identity)
             self.serviceObject.initialize()
-        except:
+        except Exception:
             self._logger.error('Service thread for %s failed:\n%s', self.instance._identity, traceback.format_exc())
 
             self.serviceObject = None
@@ -121,7 +121,7 @@ class ServiceWorker:
         try:
             self._logger.info("Starting runloop for service object %s", self.instance._identity)
             self.serviceObject.doWork(self.shouldStop)
-        except:
+        except Exception:
             self._logger.error("Service %s/%s failed: %s",
                 self.serviceName,
                 self.instance._identity,

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -200,7 +200,7 @@ class SubprocessServiceManager(ServiceManager):
                                 path = os.path.join(self.storageDir, file)
                                 self._logger.info("Removing storage at path %s for dead service.", path)
                                 shutil.rmtree(path)
-                            except:
+                            except Exception:
                                 self._logger.error("Failed to remove storage at path %s for dead service:\n%s", path, traceback.format_exc())
 
         if self.sourceDir:
@@ -212,7 +212,7 @@ class SubprocessServiceManager(ServiceManager):
                                 path = os.path.join(self.sourceDir, file)
                                 self._logger.info("Removing source caches at path %s for dead service.", path)
                                 shutil.rmtree(path)
-                            except:
+                            except Exception:
                                 self._logger.error("Failed to remove source cache at path %s for dead service:\n%s", path, traceback.format_exc())
 
 

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -205,7 +205,7 @@ with open(os.path.join(ownDir, "aws_linux_bootstrap.sh"), "r") as fh:
 class AwsApi:
     def __init__(self):
         self._logger = logging.getLogger(__name__)
-        
+
         self.config = Configuration.lookupAny()
         if not self.config:
             raise Exception("Please configure the aws service.")
@@ -300,7 +300,7 @@ class AwsApi:
 
                 try:
                     price = float(record['SpotPrice'])
-                except:
+                except Exception:
                     price = None
 
                 if (instance_type, az) not in results:
@@ -511,7 +511,7 @@ class AwsWorkerBootService(ServiceBase):
             try:
                 if not self.pushTaskLoopForward():
                     time.sleep(1.0)
-            except:
+            except Exception:
                 self._logger.error("Failed: %s", traceback.format_exc())
                 time.sleep(5.0)
 

--- a/object_database/tcp_server.py
+++ b/object_database/tcp_server.py
@@ -27,7 +27,7 @@ class ServerToClientProtocol(AlgebraicProtocol):
         def callHandler(*args):
             try:
                 return handler(*args)
-            except:
+            except Exception:
                 self._logger.error("Unexpected exception in %s:\n%s", handler.__name__, traceback.format_exc())
 
         self.handler = callHandler
@@ -217,7 +217,7 @@ class TcpServer(Server):
             _eventLoop.loop.call_later(getHeartbeatInterval(), self.checkHeartbeatsCallback)
             try:
                 self.checkForDeadConnections()
-            except:
+            except Exception:
                 logging.error("Caught exception in checkForDeadConnections:\n%s", traceback.format_exc())
 
     def stop(self):

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -137,7 +137,7 @@ class Timer:
                 if isinstance(arg, types.FunctionType):
                     try:
                         a.append(arg())
-                    except:
+                    except Exception:
                         a.append("<error>")
                 else:
                     a.append(arg)
@@ -145,7 +145,7 @@ class Timer:
             if a:
                 try:
                     m = m % tuple(a)
-                except:
+                except Exception:
                     logger.error("Couldn't format %s with %s", m, a)
 
             logger.info("%s took %.2f seconds.", m, t1 - self.t0)

--- a/object_database/view.py
+++ b/object_database/view.py
@@ -151,7 +151,7 @@ class View(object):
 
             try:
                 coerced_val = coerce_value(val, cls.__types__[kwd])
-            except:
+            except Exception:
                 raise TypeError("Can't coerce %s to type %s" % (val, cls.__types__[kwd]))
 
             writes[data_key(cls, identity, kwd)] = (cls.__types__[kwd], coerced_val)

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -503,7 +503,7 @@ class ActiveWebService(ServiceBase):
                             cell = cells.cells.get(cell_id)
                             if cell is not None:
                                 cell.onMessage(jsonMsg)
-                        except:
+                        except Exception:
                             self._logger.error("Exception in inbound message: %s", traceback.format_exc())
                         cells.triggerIfHasDirty()
 
@@ -552,7 +552,7 @@ class ActiveWebService(ServiceBase):
                     if (time.time() - timestamps[0]) < 1.0:
                         sleep(1.0 / MAX_FPS + .001)
 
-        except:
+        except Exception:
             self._logger.error("Websocket handler error: %s", traceback.format_exc())
         finally:
             if reader:

--- a/object_database/web/ActiveWebService_test.py
+++ b/object_database/web/ActiveWebService_test.py
@@ -117,7 +117,7 @@ class ActiveWebServiceTest(unittest.TestCase):
                 ServiceManager.startService("ActiveWebService", 1)
 
             self.waitUntilUp()
-        except:
+        except Exception:
             self.server.terminate()
             self.server.wait()
             raise

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -215,7 +215,7 @@ class Cells:
                             break
                         except SubscribeAndRetry as e:
                             e.callback(self.db)
-                except:
+                except Exception:
                     self._logger.error("Node %s had exception during recalculation:\n%s", n, traceback.format_exc())
                     self._logger.error("Subscribed cell threw an exception:\n%s", traceback.format_exc())
                     n.children = {'____contents__': Traceback(traceback.format_exc())}
@@ -259,7 +259,7 @@ class Cells:
 
         try:
             contents = multiReplace(contents, formatArgs)
-        except:
+        except Exception:
             raise Exception("Failed to format these contents with args %s:\n\n%s", formatArgs, contents)
 
         res = {
@@ -694,7 +694,7 @@ class Dropdown(Cell):
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
                     self._logger.error("Button click timed out. This should really fail.")
                     return
-            except:
+            except Exception:
                 self._logger.error("Exception in dropdown logic:\n%s", traceback.format_exc())
                 return
 
@@ -776,7 +776,7 @@ class Subscribed(Cell):
                 self.children = {'____contents__': c}
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self.children = {'____contents__': Traceback(traceback.format_exc())}
 
             self._resetSubscriptionsToViewReads(v)
@@ -809,7 +809,7 @@ class SubscribedSequence(Cell):
                 self.spine = list(self.itemsFun())
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self._logger.error("Spine calc threw an exception:\n%s", traceback.format_exc())
                 self.spine = []
 
@@ -824,7 +824,7 @@ class SubscribedSequence(Cell):
                         self.existingItems[s] = new_children["____child_%s__" % ix] = self.rendererFun(s)
                     except SubscribeAndRetry:
                         raise
-                    except:
+                    except Exception:
                         self.existingItems[s] = new_children["____child_%s__" % ix] = Traceback(traceback.format_exc())
 
         self.children = new_children
@@ -898,14 +898,14 @@ class Grid(Cell):
                 self.rows = list(self.rowFun())
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self._logger.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
                 self.rows = []
             try:
                 self.cols = list(self.colFun())
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self._logger.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
                 self.cols = []
 
@@ -923,7 +923,7 @@ class Grid(Cell):
                     self.existingItems[(None,col)] = new_children["____header_%s__" % col_ix] = Cell.makeCell(self.headerFun(col))
                 except SubscribeAndRetry:
                     raise
-                except:
+                except Exception:
                     self.existingItems[(None,col)] = new_children["____header_%s__" % col_ix] = Traceback(traceback.format_exc())
 
         if self.rowLabelFun is not None:
@@ -936,7 +936,7 @@ class Grid(Cell):
                         self.existingItems[(row, None)] = new_children["____rowlabel_%s__" % row_ix] = Cell.makeCell(self.rowLabelFun(row))
                     except SubscribeAndRetry:
                         raise
-                    except:
+                    except Exception:
                         self.existingItems[(row, None)] = new_children["____rowlabel_%s__" % row_ix] = Traceback(traceback.format_exc())
 
         seen = set()
@@ -950,7 +950,7 @@ class Grid(Cell):
                         self.existingItems[(row,col)] = new_children["____child_%s_%s__" % (row_ix, col_ix)] = Cell.makeCell(self.rendererFun(row,col))
                     except SubscribeAndRetry:
                         raise
-                    except:
+                    except Exception:
                         self.existingItems[(row,col)] = new_children["____child_%s_%s__" % (row_ix, col_ix)] = Traceback(traceback.format_exc())
 
         self.children = new_children
@@ -991,10 +991,10 @@ class SortWrapper:
                 return self.x < other.x
             else:
                 return str(type(self.x)) < str(type(other.x))
-        except:
+        except Exception:
             try:
                 return str(self.x) < str(self.other)
-            except:
+            except Exception:
                 return False
 
     def __eq__(self, other):
@@ -1003,10 +1003,10 @@ class SortWrapper:
                 return self.x == other.x
             else:
                 return str(type(self.x)) == str(type(other.x))
-        except:
+        except Exception:
             try:
                 return str(self.x) == str(self.other)
-            except:
+            except Exception:
                 return True
 
 class SingleLineTextBox(Cell):
@@ -1106,7 +1106,7 @@ class Table(Cell):
                     try:
                         r = self.cachedRenderFun(row, col)
                         keymemo[row] = SortWrapper(r.sortsAs())
-                    except:
+                    except Exception:
                         self._logger.error(traceback.format_exc())
                         keymemo[row] = SortWrapper(None)
 
@@ -1121,7 +1121,7 @@ class Table(Cell):
         try:
             page = max(0, int(self.curPage.get())-1)
             page = min(page, (len(rows) - 1) // self.maxRowsPerPage)
-        except:
+        except Exception:
             self._logger.error("Failed to parse current page: %s", traceback.format_exc())
 
         return rows[page * self.maxRowsPerPage:(page+1) * self.maxRowsPerPage]
@@ -1161,7 +1161,7 @@ class Table(Cell):
                 self.cols = list(self.colFun())
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self._logger.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
                 self.cols = []
 
@@ -1172,7 +1172,7 @@ class Table(Cell):
 
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self._logger.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
                 self.rows = []
 
@@ -1190,7 +1190,7 @@ class Table(Cell):
                     self.existingItems[(None,col)] = new_children["____header_%s__" % col_ix] = self.makeHeaderCell(col_ix)
                 except SubscribeAndRetry:
                     raise
-                except:
+                except Exception:
                     self.existingItems[(None,col)] = new_children["____header_%s__" % col_ix] = Traceback(traceback.format_exc())
 
         seen = set()
@@ -1204,7 +1204,7 @@ class Table(Cell):
                         self.existingItems[(row,col)] = new_children["____child_%s_%s__" % (row_ix, col_ix)] = Cell.makeCell(self.rendererFun(row,col))
                     except SubscribeAndRetry:
                         raise
-                    except:
+                    except Exception:
                         self.existingItems[(row,col)] = new_children["____child_%s_%s__" % (row_ix, col_ix)] = Traceback(traceback.format_exc())
 
         self.children = new_children
@@ -1297,7 +1297,7 @@ class Clickable(Cell):
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
                     self._logger.error("Button click timed out. This should really fail.")
                     return
-            except:
+            except Exception:
                 self._logger.error("Exception in button logic:\n%s", traceback.format_exc())
                 return
 
@@ -1526,7 +1526,7 @@ class _PlotUpdater(Cell):
                         )
             except SubscribeAndRetry:
                 raise
-            except:
+            except Exception:
                 self._logger.error(traceback.format_exc())
                 self.contents = """<div>____contents__</div>"""
                 self.children = {'____contents__': Traceback(traceback.format_exc())}

--- a/test.py
+++ b/test.py
@@ -572,7 +572,7 @@ def main(args):
         os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + ":" + os.path.abspath("./build/install")
 
         return executeTests(args, filter_actions)
-    except:
+    except Exception:
         import traceback
         logger.error("executeTests() threw an exception: \n%s", traceback.format_exc())
         return 1

--- a/typed_python/inspect_override.py
+++ b/typed_python/inspect_override.py
@@ -161,7 +161,7 @@ def findsource(pyObject):
     if isfunction(pyObject):
         try:
             pyObject = pyObject.__code__
-        except:
+        except Exception:
             print(pyObject)
             print(dir(pyObject))
             raise

--- a/typed_python/python_ast.py
+++ b/typed_python/python_ast.py
@@ -509,7 +509,7 @@ def createPythonAstConstant(n, **kwds):
 def createPythonAstString(s, **kwds):
     try:
         return Expr.Str(s=str(s), **kwds)
-    except:
+    except Exception:
         return Expr.Num(
             n=NumericConstant.Unknown(),
             **kwds
@@ -677,7 +677,7 @@ def convertPyAstToAlgebraic(tree,fname, keepLineInformation=True):
 
         try:
             return converter(**args)
-        except:
+        except Exception:
             del args['line_number']
             del args['col_offset']
             del args['filename']

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -81,7 +81,7 @@ def makeAlternative(severalDicts):
             try:
                 res.append(getattr(alt,"a_%s" % i)(**thing))
                 did = True
-            except:
+            except Exception:
                 pass
 
             if did:
@@ -124,7 +124,7 @@ class RandomValueProducer:
             whichLevel = choice(sublevels)
             try:
                 return choice(self.levels[whichLevel])
-            except:
+            except Exception:
                 print(self.levels[whichLevel])
                 raise
 


### PR DESCRIPTION
# Purpose
bare `except:` statements not only catch `Exception` but also `KeyboardInterrupt` and `SystemExit` (c.f., [PEP-0348](https://www.python.org/dev/peps/pep-0348/#new-hierarchy)), which is not desirable. So, I blindly replaced `except:` with `except Exception:` everywhere.

Tests are happy, so it's probably safe to merge