### PR TITLE
Fixing a memory leak in our Cells framework

### DIFF
--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -23,6 +23,7 @@ from object_database.tcp_server import TcpServer, connect
 from object_database.inmem_server import InMemServer
 from object_database.persistence import InMemoryPersistence, RedisPersistence
 from object_database.util import configureLogging, genToken
+from object_database.test_util import currentMemUsageMb
 
 import object_database.messages as messages
 import queue
@@ -35,15 +36,7 @@ import os
 import threading
 import random
 import time
-import psutil
 import ssl
-
-
-def currentMemUsageMb(residentOnly=True):
-    if residentOnly:
-        return psutil.Process().memory_info().rss / 1024 ** 2
-    else:
-        return psutil.Process().memory_info().vms / 1024 ** 2
 
 
 class BlockingCallback:

--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -55,9 +55,9 @@ def main(argv=None):
 
     token = genToken()
     port = 8020
-    with tempfile.TemporaryDirectory() as tf:
+    with tempfile.TemporaryDirectory() as tmpDirName:
         try:
-            server = start_service_manager(tf, port, token)
+            server = start_service_manager(tmpDirName, port, token)
 
             database = connect("localhost", port, token, retry=True)
             database.subscribeToSchema(core_schema, service_schema, active_webservice_schema)

--- a/object_database/inmem_server.py
+++ b/object_database/inmem_server.py
@@ -2,6 +2,7 @@ from object_database.server import Server
 from object_database.database_connection import DatabaseConnection
 from object_database.messages import ClientToServer, ServerToClient, getHeartbeatInterval
 from object_database.persistence import InMemoryPersistence
+
 import json
 import time
 import queue

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -5,3 +5,135 @@ def currentMemUsageMb(residentOnly=True):
         return psutil.Process().memory_info().rss / 1024 ** 2
     else:
         return psutil.Process().memory_info().vms / 1024 ** 2
+
+
+def gc_object_types_histogram():
+    """ Returns a map of types to the cound of how many such objects the GC is managing.
+
+        Return Type: defaultdict( ObjectType: type -> count: int )
+    """
+    dd = defaultdict(int)
+    gc_objects = gc.get_objects()
+    for o in gc_objects:
+        dd[type(o)] += 1
+
+    total = sum([v for v in dd.values()])
+    assert total == len(gc_objects), (total, len(gc_objects))
+
+    return dd
+
+
+def diff_object_types_histograms(new_histo, old_histo):
+    """ Returns a new histogram that is the difference of it inputs """
+    all_keys = set(new_histo.keys()).union(old_histo.keys())
+
+    dd = {k: new_histo[k] - old_histo[k]
+        for k in all_keys if new_histo[k] - old_histo[k] != 0
+    }
+    return dd
+
+
+def sort_by_value(histogram, topK=None, filterFn=None):
+    """ Return a sorted list of (value, tag) pairs from a given histogram.
+
+        If filter is specified the results are filtered using that function
+        If topK is specified, only return topK results
+    """
+    res = reversed(sorted(
+        [(val, tag) for tag, val in histogram.items()],
+        key=lambda pair: pair[0]
+    ))
+
+    if filter is not None:
+        res = filter(filterFn, res)
+
+    if topK is not None:
+        return list(res)[:topK]
+    else:
+        return list(res)
+
+
+def log_cells_stats(cells, logger, indentation=0):
+    indent = " " * indentation
+    def log(msg):
+        logger(indent + msg)
+
+    log("#####################################################")
+    log("#  Cells structure DEBUG Log")
+    log("#dirty: {}"
+        .format(len(cells._dirtyNodes)))
+    log("#need bcast: {}"
+        .format(len(cells._nodesToBroadcast)))
+    log("#cells: {}"
+        .format(len(cells._cells)))
+    log("#known children: {}"
+        .format(len(cells._cellsKnownChildren)))
+    log("#to discard: {}"
+        .format(len(cells._nodesToDiscard)))
+    log("#subscribed-to keys: {}"
+        .format(len(cells._subscribedCells)))
+    log("#####################################################")
+
+
+ownDir = os.path.dirname(os.path.abspath(__file__))
+
+def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="INFO", timeout=1.0, verbose=True):
+    if not verbose:
+        kwargs = dict(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    else:
+        kwargs = dict()
+
+    server = subprocess.Popen(
+        [sys.executable, os.path.join(ownDir, 'frontends', 'service_manager.py'),
+            'localhost', 'localhost', str(port), '--run_db',
+            '--source', os.path.join(tempDirectoryName,'source'),
+            '--storage', os.path.join(tempDirectoryName,'storage'),
+            '--service-token', auth_token,
+            '--shutdownTimeout', str(timeout / 2.0),
+            '--log-level', loglevel_name
+        ],
+        **kwargs
+    )
+    try:
+        # this should throw a subprocess.TimeoutExpired exception if the service did not crash
+        server.wait(timeout)
+    except subprocess.TimeoutExpired:
+        pass
+    else:
+        raise Exception("Failed to start service_manager (retcode:{})"
+            .format(server.returncode)
+        )
+    return server
+
+
+def autoconfigure_and_start_service_manager(port=None, auth_token=None, loglevel_name=None, **kwargs):
+    port = port or 8020
+    auth_token = auth_token or genToken()
+
+    if loglevel_name is None:
+        loglevel = logging.getLogger(__name__).getEffectiveLevel()
+        loglevel_name = logging.getLevelName(loglevel)
+
+    tempDirObj = tempfile.TemporaryDirectory()
+    tempDirectoryName = tempDirObj.__enter__()
+
+    server = start_service_manager(
+        tempDirectoryName,
+        port,
+        auth_token,
+        loglevel_name,
+        **kwargs
+    )
+
+    def cleanupFn(error=False):
+        server.terminate()
+        server.wait()
+        if error:
+            logging.getLogger(__name__).warning(
+                "Exited with an error. Leaving temporary directory around for inspection: {}"
+                .format(tempDirectoryName)
+            )
+        else:
+            tempDirObj.__exit__(None, None, None)
+
+    return server, cleanupFn

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -1,0 +1,7 @@
+import psutil
+
+def currentMemUsageMb(residentOnly=True):
+    if residentOnly:
+        return psutil.Process().memory_info().rss / 1024 ** 2
+    else:
+        return psutil.Process().memory_info().vms / 1024 ** 2

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -82,17 +82,17 @@ def log_cells_stats(cells, logger, indentation=0):
 
     log("#####################################################")
     log("#  Cells structure DEBUG Log")
-    log("#dirty: {}"
+    log("#  - dirty: {}"
         .format(len(cells._dirtyNodes)))
-    log("#need bcast: {}"
+    log("#  - need bcast: {}"
         .format(len(cells._nodesToBroadcast)))
-    log("#cells: {}"
+    log("#  - cells: {}"
         .format(len(cells._cells)))
-    log("#known children: {}"
+    log("#  - known children: {}"
         .format(len(cells._cellsKnownChildren)))
-    log("#to discard: {}"
+    log("#  - to discard: {}"
         .format(len(cells._nodesToDiscard)))
-    log("#subscribed-to keys: {}"
+    log("#  - subscribed-to keys: {}"
         .format(len(cells._subscribedCells)))
     log("#####################################################")
 

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -12,10 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.from collections import defaultdict
 
+import logging
 import os
 import psutil
 import subprocess
 import sys
+import tempfile
+
+from object_database.util import genToken
 
 
 def currentMemUsageMb(residentOnly=True):

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -1,4 +1,22 @@
+#   Copyright 2019
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+import os
 import psutil
+import subprocess
+import sys
+
 
 def currentMemUsageMb(residentOnly=True):
     if residentOnly:

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -558,6 +558,7 @@ class ActiveWebService(ServiceBase):
             if reader:
                 reader.join()
 
+    @login_required
     def echoSocket(self, ws):
         while not ws.closed:
             message = ws.receive()

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -136,10 +136,10 @@ class ActiveWebService(ServiceBase):
             return AuthPluginBase()
         elif auth_type == "LDAP":
             if not hostname:
-                raise Exception("Missing --hostname argument for LDAP")
+                raise Exception("Missing required argument for LDAP: --hostname")
 
             if not ldap_base_dn:
-                raise Exception("Missing --base-dn argument for LDAP")
+                raise Exception("Missing required argument for LDAP: --base-dn")
 
             return LdapAuthPlugin(
                 hostname=hostname,
@@ -500,7 +500,7 @@ class ActiveWebService(ServiceBase):
                             jsonMsg = json.loads(msg)
 
                             cell_id = jsonMsg.get('target_cell')
-                            cell = cells.cells.get(cell_id)
+                            cell = cells[cell_id]
                             if cell is not None:
                                 cell.onMessage(jsonMsg)
                         except Exception:
@@ -511,7 +511,6 @@ class ActiveWebService(ServiceBase):
 
             while not ws.closed:
                 t0 = time.time()
-                cells.recalculate()
                 messages = cells.renderMessages()
 
                 user = self.load_user(current_user.username)
@@ -543,7 +542,7 @@ class ActiveWebService(ServiceBase):
 
                 ws.send(json.dumps("postscripts"))
 
-                cells.gEventHasTransactions.wait()
+                cells.wait()
 
                 timestamps.append(time.time())
 

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -20,7 +20,6 @@ import typed_python.ast_util as ast_util
 import threading
 import time
 import unittest
-import psutil
 import numpy
 import gc
 import tempfile


### PR DESCRIPTION
# Purpose
We noticed that the ActiveWebService would die after running out of memory simply by idling over time. It turned out that the (or at least the main) memory-leak was in the `Cells` object, more specifically we were not cleaning-up the map of DB keys to `Cell` objects subscribed to them.

# Approach
- Lots of refactoring to make the `Cells` class more of a manager object rather than a see-through collection of datastructures.
- Some refactoring and utility functions to help testing classes stand up an out-of-process object DB more easily
- The two places where we were not cleaning up after ourselves (for the `Cells`) object were in `_cellOutOfScope` and whenever a `Cell` was resetting its `self.subscriptions` in a `prepareForReuse` call. The solution was to do the requires unsubscribing in `_cellOutOfScope` and to add a helper method called `_clearSubscriptions` in the `Cell` class to be used for clearing the `subscriptions` set.