### PR TITLE
Record login IP and refactor Login Plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ docker-test:
 .PHONY: docker-web
 docker-web:
 	#run a dummy webframework
-	docker run -it --rm -p 8000:8000 --entrypoint object_database_webtest nativepython/cloud:"$(COMMIT)"
+	docker run -it --rm --publish 8000:8000 --entrypoint object_database_webtest nativepython/cloud:"$(COMMIT)"
 
 .PHONY: lint
 lint:

--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -45,6 +45,7 @@ from object_database import (
 )
 from object_database.test_util import start_service_manager
 from object_database.util import tokenFromString, genToken
+from object_database.web.LoginPlugin import LoginIpPlugin
 
 
 ownDir = os.path.dirname(os.path.abspath(__file__))
@@ -70,8 +71,15 @@ def main(argv=None):
                 database, service,
                 ['--port', '8000',
                 '--host', '0.0.0.0',
-                '--auth', 'NONE',
                 '--log-level', 'INFO']
+            )
+
+            ActiveWebService.setLoginPlugin(
+                database,
+                service,
+                LoginIpPlugin,
+                [None],
+                config={'company_name': 'A Testing Company'}
             )
 
             with database.transaction():

--- a/object_database/object.py
+++ b/object_database/object.py
@@ -118,7 +118,7 @@ class DatabaseObject(_base):
 
     @classmethod
     def _define(cls, **types):
-        assert cls.__types__ is None, "already defined"
+        assert cls.__types__ is None, "'{}' already defined".format(cls)
         assert isinstance(types, dict)
 
         cls.__types__ = types

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -1,4 +1,4 @@
-#   Copyright 2019
+#   Copyright 2019 Nativepython Authors
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -99,7 +99,8 @@ def log_cells_stats(cells, logger, indentation=0):
 
 ownDir = os.path.dirname(os.path.abspath(__file__))
 
-def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="INFO", timeout=1.0, verbose=True):
+def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="INFO", timeout=1.0,
+                          verbose=True, own_hostname='localhost', db_hostname='localhost'):
     if not verbose:
         kwargs = dict(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:
@@ -107,7 +108,7 @@ def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="IN
 
     server = subprocess.Popen(
         [sys.executable, os.path.join(ownDir, 'frontends', 'service_manager.py'),
-            'localhost', 'localhost', str(port), '--run_db',
+            own_hostname, db_hostname, str(port), '--run_db',
             '--source', os.path.join(tempDirectoryName,'source'),
             '--storage', os.path.join(tempDirectoryName,'storage'),
             '--service-token', auth_token,

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -191,9 +191,9 @@ def closest_N_in(name, names, count):
     return [x[1] for x in sorted((distance(name, x), x) for x in names)[:count]]
 
 
-def sslContextFromCertPath(cert_path):
+def sslContextFromCertPath(cert_path, key_path=None):
     assert os.path.isfile(cert_path), "Expected path to existing SSL certificate ({})".format(cert_path)
-    key_path = os.path.splitext(cert_path)[0] + '.key'
+    key_path = key_path or os.path.splitext(cert_path)[0] + '.key'
     assert os.path.isfile(key_path), "Expected to find .key file along SSL certificate ({})".format(cert_path)
 
     ssl_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)

--- a/object_database/web/ActiveWebServiceSchema.py
+++ b/object_database/web/ActiveWebServiceSchema.py
@@ -1,0 +1,18 @@
+#   Copyright 2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+from object_database import Schema
+
+
+active_webservice_schema = Schema("core.active_webservice")

--- a/object_database/web/AuthPlugin.py
+++ b/object_database/web/AuthPlugin.py
@@ -1,60 +1,117 @@
+#   Copyright 2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+import ldap3
 import logging
-from ldap3 import Server, Connection, ALL, NTLM
 
 
 class AuthPluginBase:
-    def authenticate(self, username, password) -> bool:
-        return False
+    def authenticate(self, username, password) -> str:
+        """ Tries to authenticate with given username and password.
+
+            Returns:
+            --------
+            str
+                "" if no error occurred, and an error message otherwise
+        """
+        raise NotImplementedError("derived class must implement this method")
+
+    @property
+    def authorized_groups(self):
+        return None
 
 
 class PermissiveAuthPlugin(AuthPluginBase):
-    def authenticate(self, username, password) -> bool:
-        return True
+    " An AuthPlugin that allows anyone to login (useful for testing)"
+    def authenticate(self, username, password) -> str:
+        return ''
 
 
 class LdapAuthPlugin(AuthPluginBase):
     def __init__(self, hostname, base_dn, ntlm_domain=None, authorized_groups=None):
-        self.hostname = hostname
-        self.base_dn = base_dn
-        self.ntlm_domain = ntlm_domain
+        self._hostname = hostname
+        self._base_dn = base_dn
+        self._ntlm_domain = ntlm_domain
+        self._authorized_groups = authorized_groups
 
-        self.authorized_groups = ['CN={group}'.format(group=group) for group in authorized_groups]
-        self._logger = logging.getLogger(__name__)
+    @property
+    def authorized_groups(self):
+        return self._authorized_groups
 
-    def authenticate(self, username, password) -> bool:
-        server = Server(self.hostname, use_ssl=True, get_info=ALL)
-        if self.ntlm_domain:
-            opts = dict(authentication=NTLM)
-            ldap_username = self.ntlm_domain + '\\' + username
-            username_key = 'sAMAccountName'
+    @property
+    def _logger(self):
+        """ _logger is a property rather than being set in __init__ to allow plugin
+            objects to live in the Object Database
+        """
+        return logging.getLogger(__name__)
+
+    @property
+    def username_key(self):
+        return 'sAMAccountName' if self._ntlm_domain else 'cn'
+
+    def getLdapConnection(self, username, password):
+        server = ldap3.Server(self._hostname, use_ssl=True, get_info=ldap3.ALL)
+        if self._ntlm_domain:
+            opts = dict(authentication=ldap3.NTLM)
+            ldap_username = self._ntlm_domain + '\\' + username
         else:
             opts = dict()
-            ldap_username = 'CN={},'.format(username) + self.base_dn
-            username_key = 'cn'
+            ldap_username = 'CN={},'.format(username) + self._base_dn
 
-        with Connection(server, ldap_username, password, **opts) as conn:
-            if not conn.bound:
-                return False
-            # else conn.bound==True
-            if self.authorized_groups is None:
-                return True
-            # else check group membership
-            if not conn.search(self.base_dn, '({username_key}={username})'.format(username_key=username_key, username=username), attributes='memberOf'):
-                return False
-            if len(conn.response) != 1:
-                raise Exception(
-                    "Non-unique LDAP username: {username}".format(username=username)
-                )
-            memberOfGroups = [group.split(',')[0] for group in conn.response[0]['attributes']['memberOf']]
+        return ldap3.Connection(server, ldap_username, password, **opts)
 
-            for group in memberOfGroups:
-                if group in self.authorized_groups:
-                    return True
+    def getUserAttribute(self, connection, username:str, attributeName:str):
+        if not connection.search(
+                self._base_dn,
+                '({username_key}={username})'.format(username_key=self.username_key, username=username),
+                attributes=attributeName
+        ):
+            return None
 
-            self._logger.debug(
-                "User '{username}' authenticated successfully with LDAP "
-                "but does not belong to an authorized group: {groups}"
-                .format(username=username, groups=self.authorized_groups)
+        if len(connection.response) != 1:
+            raise Exception(
+                "Non-unique LDAP username: {username}".format(username=username)
             )
 
-            return False
+        return connection.response[0]['attributes'][attributeName]
+
+    def authenticate(self, username, password) -> str:
+        with self.getLdapConnection(username, password) as conn:
+            if not conn.bound:
+                return "Invalid username or password"
+            # else conn.bound==True -> auth to LDAP succeeded
+            if self._authorized_groups is None:
+                return ""
+            # else check group membership
+            memberOf = self.getUserAttribute(conn, username, 'memberOf')
+
+            if memberOf is None:
+                return "User '{}' is not a member of any group".format(username)
+
+        # keep the first item of a comma-separated list and then keep the
+        # last part after an equal-sign. This is because the memberOf attribute
+        # returns a sequence of list like this "CN=GroupName, OU=..., ..."
+        memberOfGroups = [group.split(',')[0].split('=')[-1] for group in memberOf]
+
+        for group in memberOfGroups:
+            if group in self._authorized_groups:
+                return ''
+
+        self._logger.debug(
+            "User '{username}' authenticated successfully with LDAP "
+            "but does not belong to an authorized group: {groups}"
+            .format(username=username, groups=self._authorized_groups)
+        )
+
+        return "User '{}' does not belong to an authorized group".format(username)

--- a/object_database/web/AuthPlugin_test.py
+++ b/object_database/web/AuthPlugin_test.py
@@ -1,0 +1,77 @@
+#   Copyright 2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+import unittest
+from unittest.mock import patch
+
+from object_database.web.AuthPlugin import LdapAuthPlugin
+
+
+class LdapAuthPluginTest(unittest.TestCase):
+
+    def test_ldap_plugin_authenticate_no_groups(self):
+        ldap_auth = LdapAuthPlugin(
+            "localhost", "bogus_base_dn", "bogus_ntlm_domain",
+            authorized_groups=None
+        )
+
+        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
+            with patch.object(ldap_auth, 'getUserAttribute') as mock_getUserAttr:
+                error = ldap_auth.authenticate("McFly", "M@rty")
+
+        self.assertEqual(error, '')
+        mock_getConn.assert_called_once()
+        self.assertEqual(mock_getUserAttr.call_count, 0)
+
+    def test_ldap_plugin_authenticate_with_groups(self):
+        ldap_auth = LdapAuthPlugin(
+            "localhost", "bogus_base_dn", "bogus_ntlm_domain",
+            authorized_groups=['Protagonists', 'Scientists']
+        )
+
+        # 1. test with users that belong to a valid group
+        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
+            with patch.object(ldap_auth,
+                              'getUserAttribute',
+                              return_value=['CN=Protagonists, OU=BackToDasFutuur',
+                                            'CN=Stars, OU=BackToDasFutuur']) as mock_getUserAttr:
+                error = ldap_auth.authenticate("McFly", "M@rty")
+
+        self.assertEqual(error, '')
+        mock_getConn.assert_called_once()
+        mock_getUserAttr.assert_called_once()
+
+        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
+            with patch.object(ldap_auth,
+                              'getUserAttribute',
+                              return_value=['CN=SideKicks, OU=BackToDasFutuur',
+                                            'CN=Scientists, OU=BackToDasFutuur']) as mock_getUserAttr:
+                error = ldap_auth.authenticate("Brown", "Emmet, Dr.")
+
+        self.assertEqual(error, '')
+        mock_getConn.assert_called_once()
+        mock_getUserAttr.assert_called_once()
+
+        # 2. test with a user that does not belong to a valid group
+        with patch.object(ldap_auth, 'getLdapConnection') as mock_getConn:
+            with patch.object(ldap_auth,
+                              'getUserAttribute',
+                              return_value=['CN=Nemesis, OU=BackToDasFutuur',
+                                            'CN=Brutes, OU=BackToDasFutuur']) as mock_getUserAttr:
+                error = ldap_auth.authenticate("Tannen", "B1ff")
+
+        self.assertNotEqual(error, '')
+        mock_getConn.assert_called_once()
+        mock_getUserAttr.assert_called_once()
+

--- a/object_database/web/LoginPlugin.py
+++ b/object_database/web/LoginPlugin.py
@@ -1,0 +1,276 @@
+#   Copyright 2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+import logging
+import time
+
+from flask_login import current_user, login_user, logout_user
+from flask import flash, redirect, render_template, url_for
+
+from typed_python import Float64
+from object_database.web.ActiveWebServiceSchema import active_webservice_schema
+from object_database.web.flask_util import request_ip_address, next_url
+from object_database.view import revisionConflictRetry
+from object_database import Indexed
+
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, BooleanField, SubmitField
+from wtforms.validators import DataRequired
+
+
+class FlaskUser:
+    """ User class that implements to the flask-login User API.
+
+        We make these objects from our ObjectDB User classes so that Flask can
+        handle them without having to hold a view into ObjectDB
+    """
+    @staticmethod
+    def makeFromUser(user):
+        if user is None:
+            return None
+        else:
+            return FlaskUser(user.username, user.login_expiration, user.login_ip)
+
+    def __init__(self, username, login_expiration, login_ip):
+        self.username = username
+        self.login_expiration = login_expiration
+        self.login_ip = login_ip
+
+    @property
+    def is_authenticated(self) -> bool:
+        if time.time() >= self.login_expiration:
+            return False
+        elif request_ip_address() != self.login_ip:
+            return False
+        else:
+            return True
+
+    @property
+    def is_active(self) -> bool:
+        return True
+
+    @property
+    def is_anonymous(self):
+        return True if self.username.lower() == 'anonymous' else False
+
+    def get_id(self) -> str:
+        return self.username  # must return unicode by Python 3 strings are unicode
+
+
+class LoginPluginInterface:
+    """ Interface for a class that implements a login flow for a Flask app.
+
+        The derived class will register `/login` and `/logout` endpoints with
+        the Flask app and it will provide a load_user method.
+    """
+    REQUIRED_KEYS = None
+
+    def __init__(self, object_db, auth_plugins, config=None):
+        raise NotImplementedError("derived class must implement this method")
+
+    def init_app(self, flask_app):
+        raise NotImplementedError("derived class must implement this method")
+
+    def getSerializationContext(self):
+        raise NotImplementedError("derived class must implement this method")
+
+    def load_user(self, username) -> FlaskUser:
+        raise NotImplementedError("derived class must implement this method")
+
+    @property
+    def authorized_groups(self):
+        raise NotImplementedError("derived class must implement this method")
+
+    def init_config(self, config):
+        if config is None:
+            config = {}
+
+        if self.REQUIRED_KEYS:
+            for key in self.REQUIRED_KEYS:
+                if key not in config:
+                    raise Exception("{cls} missing configuration parameter '{key}'"
+                        .format(cls=self.__class__.__name__, key=key)
+                    )
+                setattr(self, '_' + key, config[key])
+
+
+class LoginForm(FlaskForm):
+    username = StringField('Username', validators=[DataRequired()])
+    password = PasswordField('Password', validators=[DataRequired()])
+    remember_me = BooleanField('Remember Me')
+    submit = SubmitField('Sign In')
+
+
+USER_LOGIN_DURATION = 24 * 60 * 60  # 24 hours
+
+@active_webservice_schema.define
+class User:
+    username = Indexed(str)
+    login_expiration = Float64
+    login_ip = str
+
+    def login(self, login_ip):
+        self.login_expiration = time.time() + USER_LOGIN_DURATION
+        self.login_ip = login_ip
+
+    def logout(self):
+        self.login_expiration = 0.0
+        self.login_ip = ""
+
+
+def authorized_groups_text(authorized_groups, default_text='All') -> str:
+    """ Helper function that returns a string for display purposes. """
+    res = default_text
+    if authorized_groups:
+        return ', '.join(authorized_groups)
+
+
+class LoginIpPlugin(LoginPluginInterface):
+    REQUIRED_KEYS = ['company_name']
+
+    def __init__(self, db, auth_plugins, config=None):
+        self._logger = logging.getLogger(__name__)
+        self._db = db
+        self._db.subscribeToType(User)
+
+        if len(auth_plugins) != 1:
+            raise Exception(
+                "LoginIpPlugin requires exactly 1 auth_plugin but {} were given."
+                .format(len(auth_plugins))
+            )
+
+        self._auth_plugins = auth_plugins
+        self._auth_plugin = auth_plugins[0]
+
+        self._authorized_groups_text = authorized_groups_text(self.authorized_groups)
+
+        self.init_config(config)
+
+    def init_app(self, flask_app):
+        flask_app.add_url_rule('/login', endpoint=None, view_func=self.login, methods=['GET', 'POST'])
+        flask_app.add_url_rule('/logout', endpoint=None, view_func=self.logout)
+
+    @property
+    def authorized_groups_text(self):
+        return self._authorized_groups_text
+
+    @property
+    def authorized_groups(self):
+        return self._auth_plugin.authorized_groups if self._auth_plugin is not None else None
+
+    def _authenticate(self, username, password) -> str:
+        """ Attempts to authenticate with given username and password.
+
+            Returns:
+            --------
+            str
+                "" (empty string) if no error occurred and an error message otherwise
+        """
+        login_ip = request_ip_address()
+        self._logger.info("User '{username}' trying to authenticate from IP {login_ip}".
+            format(username=username, login_ip=login_ip)
+        )
+        # error = self.authenticate(username, password, login_ip=login_ip)
+        if not self.bypassAuth:
+            error = self._auth_plugin.authenticate(username, password)
+            if error:
+                return error
+
+        self._login_user(username, login_ip)
+        return ''
+
+    def login(self):
+        if current_user.is_authenticated:
+            return redirect(next_url())
+
+        if self.bypassAuth:
+            error = self._authenticate('anonymous', 'fake-pass')
+            assert not error, error
+            return redirect(next_url())
+
+        form = LoginForm()
+
+        def render(error=None):
+            if error:
+                flash(error, 'danger')
+            return render_template(
+                'login.html',
+                form=form,
+                title=self._company_name,
+                authorized_groups_text=self.authorized_groups_text
+            )
+
+        if form.validate_on_submit():
+            username = form.username.data
+            password = form.password.data
+
+            error = self._authenticate(username, password)
+            if error:
+                return render(error)
+            else:
+                return redirect(next_url())
+
+        return render(error=form.errors)
+
+    def logout(self):
+        current_username = current_user.username
+        self._logout_user(current_username)
+        return redirect(url_for('index'))  # FIXME: we are assuming the app has defined the 'index' endpoint
+
+    def load_user(self, username):
+        with self._db.view():
+            return FlaskUser.makeFromUser(User.lookupAny(username=username))
+
+    @property
+    def bypassAuth(self):
+        return self._auth_plugin is None
+
+    def _login_user(self, username, login_ip):
+        self._login_objdb_user(username, login_ip)
+        self._login_flask_user(username)
+
+    @revisionConflictRetry
+    def _login_objdb_user(self, username, login_ip):
+        with self._db.transaction():
+            users = User.lookupAll(username=username)
+
+            if len(users) == 0:
+                user = User(username=username)
+            elif len(users) == 1:
+                user = users[0]
+            elif len(users) > 1:
+                raise Exception("multiple users found with username={}".format(username))
+            else:
+                raise Exception("This should never happen: len(users)={}".format(len(users)))
+
+            user.login(login_ip)
+
+    def _login_flask_user(self, username):
+        flask_user = self.load_user(username)
+        login_user(flask_user)
+
+    def _logout_user(self, username):
+        self._logout_objdb_user(username)
+        self._logout_flask_user()
+
+    @revisionConflictRetry
+    def _logout_objdb_user(self, username):
+        with self._db.transaction():
+            user = User.lookupAny(username=username)
+
+            if user is not None:
+                user.logout()
+
+    def _logout_flask_user(self):
+        logout_user()

--- a/object_database/web/LoginPlugin_test.py
+++ b/object_database/web/LoginPlugin_test.py
@@ -1,0 +1,41 @@
+#   Copyright 2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+
+import unittest
+from unittest.mock import patch, Mock
+
+from object_database.web.AuthPlugin import PermissiveAuthPlugin
+from object_database.web.LoginPlugin import LoginIpPlugin
+
+
+class LoginIpPluginTest(unittest.TestCase):
+    def test_login_plugin_init(self):
+        db = Mock()
+        login_config = dict(company_name="Testing Company")
+
+        with self.assertRaisesRegex(Exception, "missing config"):
+            lp = LoginIpPlugin(db, [None], {})
+
+        with self.assertRaisesRegex(Exception, "LoginIpPlugin requires exactly 1"):
+            LoginIpPlugin(db, [None, None], login_config)
+
+        lp = LoginIpPlugin(db, [None], login_config)
+        self.assertTrue(lp.bypassAuth)
+        lp.authorized_groups_text
+        self.assertIs(lp.authorized_groups, None)
+
+        lp = LoginIpPlugin(db, [PermissiveAuthPlugin()], login_config)
+        lp.authorized_groups_text
+        self.assertIs(lp.authorized_groups, None)

--- a/object_database/web/flask_util.py
+++ b/object_database/web/flask_util.py
@@ -64,6 +64,15 @@ def next_url(fallback_url=None, fallback_endpoint='index', next_key='next',
     return target_url
 
 
+def url_with_request_parameters(url, req=None, filtr=None):
+    req = req or request
+    for k, v in req.args.items():
+        if filtr and k not in filtr:
+            continue
+        url = set_query_parameter(url, k, v)
+    return url
+
+
 def set_query_parameter(url, param_name, param_value):
     """Given a URL, set or replace a query parameter and return the result. """
     scheme, netloc, path, query_string, fragment = urlsplit(url)

--- a/object_database/web/flask_util.py
+++ b/object_database/web/flask_util.py
@@ -1,0 +1,75 @@
+#   Copyright 2019 Nativepython Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.from collections import defaultdict
+
+from flask import (
+    abort,
+    has_request_context,
+    request,
+    url_for,
+)
+
+from urllib.parse import urlparse, urljoin, urlencode, parse_qs, urlsplit, urlunsplit
+
+
+def request_ip_address():
+    assert has_request_context()
+    return request.remote_addr
+
+
+def is_safe_url(target, require_https=None, forbid_cross_site=None):
+
+    require_https = False if require_https is None else require_https
+    forbid_cross_site = True if forbid_cross_site is None else forbid_cross_site
+
+    allowed_schemes = ('https', ) if require_https else ('https', 'http')
+
+    ref_url = urlparse(request.host_url)
+    test_url = urlparse(urljoin(request.host_url, target))
+
+    cross_site_check = ref_url.netloc == test_url.netloc if forbid_cross_site else True
+
+    return test_url.scheme in allowed_schemes and cross_site_check
+
+
+
+def next_url(fallback_url=None, fallback_endpoint='index', next_key='next',
+             logger=None, require_https=None, forbid_cross_site=None):
+    target_url = request.args.get(next_key)
+
+    if not target_url:
+        target_url = fallback_url or url_for(fallback_endpoint)
+
+    if not target_url:
+        if logger:
+            logger.error("ERROR: failed to resolve target URL during redirect.")
+        return abort(400)
+
+    # is_safe_url should check if the url is safe for redirects.
+    if not is_safe_url(target_url, require_https=require_https, forbid_cross_site=forbid_cross_site):
+        if logger:
+            logger.error("ERROR: not safe for redirect: {}".format(target_url))
+        return abort(400)
+
+    return target_url
+
+
+def set_query_parameter(url, param_name, param_value):
+    """Given a URL, set or replace a query parameter and return the result. """
+    scheme, netloc, path, query_string, fragment = urlsplit(url)
+    query_params = parse_qs(query_string)
+
+    query_params[param_name] = [param_value]
+    new_query_string = urlencode(query_params, doseq=True)
+
+    return urlunsplit((scheme, netloc, path, new_query_string, fragment))

--- a/object_database/web/templates/base.html
+++ b/object_database/web/templates/base.html
@@ -21,7 +21,7 @@
           <div class="card-body">
             <div>
               {% if title %}
-              <b>{{ title }}</b>
+              <h1>{{ title }}</h1>
               {% endif %}
             </div>
             <hr>

--- a/object_database/web/templates/error.html
+++ b/object_database/web/templates/error.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h3><span style="color: red;">ERROR:</span> {{ error_message }}</h3>
+<a href="/login">Log In</a>
+{% endblock %}

--- a/typed_python/Codebase.py
+++ b/typed_python/Codebase.py
@@ -192,7 +192,7 @@ class Codebase:
         with _lock:
             if rootDirectory is None:
                 # this works, despite the fact that we immediately destroy
-                # the directory, becauuse we use 'makedirs' below to repopulate.
+                # the directory, because we use 'makedirs' below to repopulate.
                 rootDirectory = tempfile.TemporaryDirectory().name
 
             for fpath, fcontents in filesToContents.items():
@@ -209,7 +209,7 @@ class Codebase:
 
             sys.path = [rootDirectory] + sys.path
 
-            #get a list of all modules and import each one
+            # get a list of all modules and import each one
             modules_by_name = Codebase.filesToModuleNames(filesToContents)
 
             try:
@@ -220,8 +220,8 @@ class Codebase:
 
             codebase = Codebase(rootDirectory, filesToContents, modules)
 
-            #now make sure we install these modules in our cache so that later
-            #we can walk them if we need to.
+            # now make sure we install these modules in our cache so that later
+            # we can walk them if we need to.
             for m in modules:
                 if "." not in m:
                     _root_level_module_codebase_cache[modules[m]] = codebase

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -791,7 +791,6 @@ class TypesSerializationTest(unittest.TestCase):
     def test_serialize_reduce(self):
         inst = AAA()
         loaded = ping_pong(inst, sc)
-        import pdb; pdb.set_trace()
         self.assertEqual(loaded, REDUCE_A)
 
     # FAILS with: TypeError: tp_new threw an exception
@@ -825,7 +824,6 @@ class TypesSerializationTest(unittest.TestCase):
         import os
 
         t = time.localtime()
-        import pdb; pdb.set_trace()
         u = ping_pong(t)
         self.assert_is_copy(t, u)
         if hasattr(os, "stat"):


### PR DESCRIPTION
# Purpose
- Keep a record of the IP address from which the user logged in last. 
- Require re-login when the current IP does not match the login-IP.
- Refacor the login-flow of the flask-app into a `LoginPlugin`, which now becomes the consumer of the `AuthPlugins`

# Approach
- The `LoginPlugin` object is responsible for registering the `login` and `logout` enpoints with the `Flask` app. It assumes that the Flask app is using the `flask-login` module to protect enpoints it needs with requiring users to be authenticated.
- When a user logs in, record their IP address in the `User` model, along with the login expiration. When checking whether a user is authenticated, compare the login IP with the current request IP.

