### PR TITLE
Declare our dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,22 @@ setuptools.setup(
             ]
         )
     ],
+    install_requires=[
+        'boto3',
+        'flask-login',
+        'flask-sockets',
+        'flask-wtf',
+        'gevent',
+        'ldap3',
+        'llvmlite',
+        'lz4',
+        'numpy',
+        'psutil',
+        'pyyaml',
+        'redis',
+        'requests',
+        'websockets',
+    ],
     classifiers=[
         "Programming Language :: Python :: 3"
     ],


### PR DESCRIPTION
This allows `pip` (and `pipenv`) to fetch the dependencies when installing this package.