### PR TITLE
Codebase fixups

### DIFF
--- a/typed_python/Codebase.py
+++ b/typed_python/Codebase.py
@@ -260,8 +260,11 @@ class Codebase:
     def rootlevelPathFromModule(module):
         module_path = os.path.abspath(module.__file__)
 
-        # drop as many parts of the module_path as there are parts to the
-        # module name (i.e., at least one)
+        if os.path.basename(module_path) == '__init__.py':
+            module_path = os.path.dirname(module_path)
+
+        # drop as many parts of the module_path as there dots to the
+        # module name
         for _ in range(len(module.__name__.split("."))-1):
             module_path = os.path.dirname(module_path)
 

--- a/typed_python/Codebase.py
+++ b/typed_python/Codebase.py
@@ -22,8 +22,6 @@ import logging
 
 from typed_python.SerializationContext import SerializationContext
 
-import object_database, typed_python
-
 _lock = threading.RLock()
 _root_level_module_codebase_cache = {}
 _coreSerializationContext = [None]
@@ -65,6 +63,8 @@ class Codebase:
     def coreSerializationContext():
         with _lock:
             if _coreSerializationContext[0] is None:
+                import object_database, typed_python
+
                 allModules = []
 
                 context1 = SerializationContext.FromModules(

--- a/typed_python/Codebase_test.py
+++ b/typed_python/Codebase_test.py
@@ -12,7 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import os
 import unittest
+import sys
 
 from typed_python.Codebase import Codebase
 
@@ -29,3 +31,17 @@ class CodebaseTest(unittest.TestCase):
         self.assertEqual(codebase2.getClassByName('test_module.inner.f')(), 10)
 
         self.assertEqual(codebase.filesToContents, codebase2.filesToContents)
+
+    def test_rootlevelPathFromModule(self):
+
+        def check_module_name(mod_name):
+            mod = sys.modules[mod_name]
+            path = Codebase.rootlevelPathFromModule(mod)
+            self.assertEqual(os.path.basename(path), 'typed_python')
+
+        mod_name_parts = Codebase.__module__.split('.')
+
+        for parts in range(len(mod_name_parts)):
+            check_module_name(
+                '.'.join(mod_name_parts[:parts+1])
+            )


### PR DESCRIPTION
- `rootlevelPathFromModule` needed a fixup to work correctly when the input is a root module (such as `typed_python`)
- moving an `import` inside the function that needs it in order to avoid cyclic import problems (e.g., we could not `import typed_python.Codebase` without this change).