### PR TITLE
Pytz dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,6 @@ nose = "*"
 flake8 = "*"
 autopep8 = "*"
 beautifulsoup4 = "*"
-pytz = "*"
 
 [packages]
 redis = "*"
@@ -27,6 +26,7 @@ pyyaml = "*"
 ldap3 = "*"
 flask-login = "*"
 flask-wtf = "*"
+pytz = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fbb0f5c3501780db69c92a1a1a7fa01b1b1059eebd5ee11d09a414d9357eb496"
+            "sha256": "ab74724e765c49e5e02a2727d24dec76cfc3d8d9b09dfa2f0a64397c5cc6706b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -321,18 +321,18 @@
         },
         "psutil": {
             "hashes": [
-                "sha256:04d2071100aaad59f9bcbb801be2125d53b2e03b1517d9fed90b45eea51d297e",
-                "sha256:1aba93430050270750d046a179c5f3d6e1f5f8b96c20399ba38c596b28fc4d37",
-                "sha256:3ac48568f5b85fee44cd8002a15a7733deca056a191d313dbf24c11519c0c4a8",
-                "sha256:96f3fdb4ef7467854d46ad5a7e28eb4c6dc6d455d751ddf9640cd6d52bdb03d7",
-                "sha256:b755be689d6fc8ebc401e1d5ce5bac867e35788f10229e166338484eead51b12",
-                "sha256:c8ee08ad1b716911c86f12dc753eb1879006224fd51509f077987bb6493be615",
-                "sha256:d0c4230d60376aee0757d934020b14899f6020cd70ef8d2cb4f228b6ffc43e8f",
-                "sha256:d23f7025bac9b3e38adc6bd032cdaac648ac0074d18e36950a04af35458342e8",
-                "sha256:f0fcb7d3006dd4d9ccf3ccd0595d44c6abbfd433ec31b6ca177300ee3f19e54e"
+                "sha256:5ce6b5eb0267233459f4d3980c205828482f450999b8f5b684d9629fea98782a",
+                "sha256:72cebfaa422b7978a1d3632b65ff734a34c6b34f4578b68a5c204d633756b810",
+                "sha256:77c231b4dff8c1c329a4cd1c22b96c8976c597017ff5b09993cd148d6a94500c",
+                "sha256:8846ab0be0cdccd6cc92ecd1246a16e2f2e49f53bd73e522c3a75ac291e1b51d",
+                "sha256:a013b4250ccbddc9d22feca0f986a1afc71717ad026c0f2109bbffd007351191",
+                "sha256:ad43b83119eeea6d5751023298cd331637e542cbd332196464799e25a5519f8f",
+                "sha256:c177777c787d247d02dae6c855330f9ed3e1abf8ca1744c26dd5ff968949999a",
+                "sha256:ec1ef313530a9457e48d25e3fdb1723dfa636008bf1b970027462d46f2555d59",
+                "sha256:ef3e5e02b3c5d1df366abe7b4820400d5c427579668ad4465ff189d28ded5ebd"
             ],
             "index": "pypi",
-            "version": "==5.5.0"
+            "version": "==5.5.1"
         },
         "pyasn1": {
             "hashes": [
@@ -348,6 +348,14 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
+                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+            ],
+            "index": "pypi",
+            "version": "==2018.9"
         },
         "pyyaml": {
             "hashes": [
@@ -507,14 +515,6 @@
                 "sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd"
             ],
             "version": "==2.1.0"
-        },
-        "pytz": {
-            "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
-            ],
-            "index": "pypi",
-            "version": "==2018.9"
         },
         "soupsieve": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setuptools.setup(
         'lz4',
         'numpy',
         'psutil',
+        'pytz',
         'pyyaml',
         'redis',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,16 @@
 import setuptools
 import pkg_resources
 
+
+def is_numpy_installed():
+    try:
+        import numpy
+        numpy_installed = True
+    except ImportError:
+        numpy_installed = False
+    return numpy_installed
+
+
 setuptools.setup(
     name='nativepython',
     version='0.0.1',
@@ -45,7 +55,7 @@ setuptools.setup(
             ],
             include_dirs=[
                 pkg_resources.resource_filename('numpy', 'core/include')
-            ]
+            ] if is_numpy_installed() else []
         )
     ],
     install_requires=[


### PR DESCRIPTION
# Purpose
pytz is a regular dependency, not a "dev" dependency: it is included in typed_python/SerializationContext.py which is not a test file.

# Approach
- list pytz in setup.py
- move it from the "dev" to the "packages" section of the `Pipfile` dependencies