### PR TITLE
Lint: Some semantic fixes (& some more cosmetic stuff)

### DIFF
--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -23,10 +23,10 @@ from nativepython.type_wrappers.none_wrapper import NoneWrapper
 from nativepython.python_object_representation import pythonObjectRepresentation, typedPythonTypeToTypeWrapper
 from nativepython.typed_expression import TypedExpression
 from nativepython.conversion_exception import ConversionException
+from typed_python import *
+
 
 NoneExprType = NoneWrapper()
-
-from typed_python import *
 
 typeWrapper = lambda t: nativepython.python_object_representation.typedPythonTypeToTypeWrapper(t)
 

--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -30,7 +30,8 @@ NoneExprType = NoneWrapper()
 
 typeWrapper = lambda t: nativepython.python_object_representation.typedPythonTypeToTypeWrapper(t)
 
-ExpressionIntermediate = Alternative("ExpressionIntermediate",
+ExpressionIntermediate = Alternative(
+    "ExpressionIntermediate",
     Effect={"expr": native_ast.Expression},
     Terminal={"expr": native_ast.Expression},
     Simple={"name": str, "expr": native_ast.Expression},
@@ -587,7 +588,7 @@ class ExpressionConversionContext(object):
                         return None
                 elif expr_so_far[-1].matches.Constant:
                     if (expr_so_far[-1].val.val and op.matches.Or
-                        or (not expr_so_far[-1].val.val) and op.matches.And):
+                            or (not expr_so_far[-1].val.val) and op.matches.And):
                         # this is a short-circuit
                         if len(expr_so_far) == 1:
                             return expr_so_far[0]

--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -317,8 +317,9 @@ class ExpressionConversionContext(object):
                 self.pushEffect(
                     native_ast.Expression.While(
                         cond=scope.counter.nonref_expr.lt(countExpr.nonref_expr),
-                        while_true=result >>
-                            scope.counter.expr.store(scope.counter.nonref_expr.add(native_ast.const_int_expr(1))),
+                        while_true=result >> scope.counter.expr.store(
+                            scope.counter.nonref_expr.add(native_ast.const_int_expr(1))
+                        ),
                         orelse=native_ast.nullExpr
                     )
                 )

--- a/nativepython/expression_conversion_context.py
+++ b/nativepython/expression_conversion_context.py
@@ -586,8 +586,8 @@ class ExpressionConversionContext(object):
                     if len(expr_so_far) == 1:
                         return None
                 elif expr_so_far[-1].matches.Constant:
-                    if (expr_so_far[-1].val.val and op.matches.Or or
-                                (not expr_so_far[-1].val.val) and op.matches.And):
+                    if (expr_so_far[-1].val.val and op.matches.Or
+                        or (not expr_so_far[-1].val.val) and op.matches.And):
                         # this is a short-circuit
                         if len(expr_so_far) == 1:
                             return expr_so_far[0]

--- a/nativepython/function_conversion_context.py
+++ b/nativepython/function_conversion_context.py
@@ -125,7 +125,6 @@ class FunctionConversionContext(object):
         if self._star_args_name is not None:
             star_args_count = len(input_types) - len(self._ast_arg.args)
 
-            starargs_elts = []
             for i in range(len(self._ast_arg.args), len(input_types)):
                 self._native_args.append(
                     ('.star_args.%s' % (i - len(self._ast_arg.args)),

--- a/nativepython/function_conversion_context.py
+++ b/nativepython/function_conversion_context.py
@@ -22,10 +22,9 @@ from nativepython.type_wrappers.none_wrapper import NoneWrapper
 from nativepython.python_object_representation import pythonObjectRepresentation, typedPythonTypeToTypeWrapper
 from nativepython.typed_expression import TypedExpression
 from nativepython.conversion_exception import ConversionException
+from typed_python import *
 
 NoneExprType = NoneWrapper()
-
-from typed_python import *
 
 typeWrapper = lambda t: nativepython.python_object_representation.typedPythonTypeToTypeWrapper(t)
 

--- a/nativepython/function_conversion_context.py
+++ b/nativepython/function_conversion_context.py
@@ -111,7 +111,7 @@ class FunctionConversionContext(object):
             if len(input_types) < len(self._ast_arg.args):
                 raise ConversionException(
                     "Expected at least %s arguments but got %s" %
-                        (len(self._ast_arg.args), len(input_types))
+                    (len(self._ast_arg.args), len(input_types))
                 )
 
         self._native_args = []
@@ -489,9 +489,14 @@ class FunctionConversionContext(object):
                         # we can just copy this into the stackslot directly. no destructor needed
                         context.pushEffect(
                             native_ast.Expression.Store(
-                                ptr=native_ast.Expression.StackSlot(name=name, type=slot_type.getNativeLayoutType()),
-                                val=native_ast.Expression.Variable(name=name) if not slot_type.is_pass_by_ref else
+                                ptr=native_ast.Expression.StackSlot(
+                                    name=name,
+                                    type=slot_type.getNativeLayoutType()
+                                ),
+                                val=(
+                                    native_ast.Expression.Variable(name=name) if not slot_type.is_pass_by_ref else
                                     native_ast.Expression.Variable(name=name).load()
+                                )
                             )
                         )
                         context.pushEffect(

--- a/nativepython/function_conversion_context.py
+++ b/nativepython/function_conversion_context.py
@@ -543,8 +543,8 @@ class FunctionConversionContext(object):
 
         if destructors:
             expr = native_ast.Expression.Finally(
-                    teardowns=destructors,
-                    expr=expr
+                teardowns=destructors,
+                expr=expr
             )
 
         return expr

--- a/nativepython/llvm_compiler.py
+++ b/nativepython/llvm_compiler.py
@@ -44,7 +44,7 @@ ctypes.CDLL(_types.__file__, mode=ctypes.RTLD_GLOBAL)
 
 pointer_size = (
     llvmlite.ir.PointerType(llvmlite.ir.DoubleType())
-        .get_abi_size(target_machine.target_data)
+    .get_abi_size(target_machine.target_data)
 )
 
 assert pointer_size == native_ast_to_llvm.pointer_size
@@ -56,7 +56,7 @@ def sizeof_native_type(native_type):
 
     return (
         native_ast_to_llvm.type_to_llvm_type(native_type)
-            .get_abi_size(target_machine.target_data)
+        .get_abi_size(target_machine.target_data)
     )
 
 

--- a/nativepython/llvm_compiler.py
+++ b/nativepython/llvm_compiler.py
@@ -192,9 +192,9 @@ class Compiler:
             input_types = [x[1] for x in functions[fname].args]
             output_type = functions[fname].output_type
 
-            native_function_pointers[fname] = NativeFunctionPointer(fname, func_ptr,
-                                                  input_types, output_type)
-
+            native_function_pointers[fname] = NativeFunctionPointer(
+                fname, func_ptr, input_types, output_type
+            )
             self.functions_by_name[fname] = native_function_pointers[fname]
 
         return native_function_pointers
@@ -231,9 +231,9 @@ class Compiler:
             input_types = [x[1] for x in functions[fname].args]
             output_type = functions[fname].output_type
 
-            native_function_pointers[fname] = NativeFunctionPointer(fname, func_ptr,
-                                                  input_types, output_type)
-
+            native_function_pointers[fname] = NativeFunctionPointer(
+                fname, func_ptr, input_types, output_type
+            )
             self.functions_by_name[fname] = native_function_pointers[fname]
 
         return native_function_pointers

--- a/nativepython/native_ast.py
+++ b/nativepython/native_ast.py
@@ -68,12 +68,12 @@ Type = Alternative("Type",
     __str__=type_str,
     pointer=lambda self: Type.Pointer(value_type=self),
     zero=lambda self: Expression.Constant(
-            Constant.Void() if self.matches.Void else
-            Constant.Float(val=0.0, bits=self.bits) if self.matches.Float else
-            Constant.Int(val=0, bits=self.bits, signed=self.signed) if self.matches.Int else
-            Constant.Struct(elements=[(name, t.zero()) for name, t in self.element_types]) if self.matches.Struct else
-            Constant.NullPointer(value_type=self.value_type) if self.matches.Pointer else
-            raising(Exception("Can't make a zero value from %s" % self))
+        Constant.Void() if self.matches.Void else
+        Constant.Float(val=0.0, bits=self.bits) if self.matches.Float else
+        Constant.Int(val=0, bits=self.bits, signed=self.signed) if self.matches.Int else
+        Constant.Struct(elements=[(name, t.zero()) for name, t in self.element_types]) if self.matches.Struct else
+        Constant.NullPointer(value_type=self.value_type) if self.matches.Pointer else
+        raising(Exception("Can't make a zero value from %s" % self))
     )
 )
 
@@ -161,13 +161,13 @@ Expression = lambda: Expression
 Teardown = lambda: Teardown
 
 NamedCallTarget = NamedTuple(
-                name=str,
-                arg_types=TupleOf(Type),
-                output_type=Type,
-                external=bool,
-                varargs=bool,
-                intrinsic=bool,
-                can_throw=bool
+    name=str,
+    arg_types=TupleOf(Type),
+    output_type=Type,
+    external=bool,
+    varargs=bool,
+    intrinsic=bool,
+    can_throw=bool
 )
 
 
@@ -233,7 +233,7 @@ def expr_str(self):
         e = str(self.expr)
         if "\n" in self.comment or "\n" in e:
             return "\n\t/*" + self.comment + "*/\n"\
-                    + indent(str(self.expr).rstrip(), "    ") + "\n"
+                + indent(str(self.expr).rstrip(), "    ") + "\n"
         else:
             return "/*" + str(self.comment) + "*/" + str(self.expr)
     if self.matches.Constant:
@@ -275,12 +275,12 @@ def expr_str(self):
         f = str(self.false)
         if "\n" in t or "\n" in f:
             return "if " + str(self.cond) + ":\n"\
-                    + indent(t).rstrip() + ("\nelse:\n" + indent(f).rstrip() if self.false != nullExpr else "")
+                + indent(t).rstrip() + ("\nelse:\n" + indent(f).rstrip() if self.false != nullExpr else "")
         else:
             return "((%s) if %s else (%s))" % (t, str(self.cond), f)
     if self.matches.MakeStruct:
         return "struct(" + \
-                ",".join("%s=%s" % (k, str(v)) for k, v in self.args) + ")"
+            ",".join("%s=%s" % (k, str(v)) for k, v in self.args) + ")"
     if self.matches.While:
         t = str(self.while_true)
         f = str(self.orelse)

--- a/nativepython/native_ast.py
+++ b/nativepython/native_ast.py
@@ -56,7 +56,8 @@ def raising(e):
     raise e
 
 
-Type = Alternative("Type",
+Type = Alternative(
+    "Type",
     Void={},
     Float={'bits': int},
     Int={'bits': int, 'signed': bool},
@@ -107,7 +108,8 @@ def const_str(c):
     assert False, type(c)
 
 
-Constant = Alternative("Constant",
+Constant = Alternative(
+    "Constant",
     Void={},
     Float={'val': float, 'bits': int},
     Int={'val': int, 'bits': int, 'signed': bool},
@@ -131,7 +133,8 @@ UnaryOp = Alternative(
         "~" if o.matches.BitwiseNot else "unknown unary op"
 )
 
-BinaryOp = Alternative("BinaryOp",
+BinaryOp = Alternative(
+    "BinaryOp",
     Add={}, Sub={}, Mul={}, Div={}, Eq={},
     NotEq={}, Lt={}, LtE={}, Gt={}, GtE={},
     Mod={}, LShift={}, RShift={},
@@ -193,7 +196,8 @@ def filterCallTargetArgs(args):
     return res
 
 
-CallTarget = Alternative("CallTarget",
+CallTarget = Alternative(
+    "CallTarget",
     Named={'target': NamedCallTarget},
     Pointer={'expr': Expression},
     call=lambda self, *args: Expression.Call(target=self, args=filterCallTargetArgs(args))
@@ -208,7 +212,8 @@ def teardown_str(self):
     assert False, type(self)
 
 
-Teardown = Alternative("Teardown",
+Teardown = Alternative(
+    "Teardown",
     ByTag={'tag': str, 'expr': Expression},
     Always={'expr': Expression},
     __str__=teardown_str
@@ -294,11 +299,14 @@ def expr_str(self):
     if self.matches.Let:
         if self.val.matches.Sequence and len(self.val.vals) > 1:
             return str(
-                Expression.Sequence(vals=self.val.vals[:-1] +
-                    (Expression.Let(
-                        var=self.var,
-                        val=self.val.vals[-1],
-                        within=self.within),)
+                Expression.Sequence(
+                    vals=(
+                        self.val.vals[:-1] +
+                        (Expression.Let(
+                            var=self.var,
+                            val=self.val.vals[-1],
+                            within=self.within), )
+                    )
                 )
             )
         valstr = str(self.val)
@@ -496,7 +504,8 @@ def const_bytes_cstr(i):
     )
 
 
-FunctionBody = Alternative("FunctionBody",
+FunctionBody = Alternative(
+    "FunctionBody",
     Internal={'body': Expression},
     External={'name': str}
 )

--- a/nativepython/native_ast.py
+++ b/nativepython/native_ast.py
@@ -312,7 +312,7 @@ def expr_str(self):
     if self.matches.Finally:
         return (
             "try:\n" + indent(str(self.expr)) + "\nfinally:\n"
-                + indent("\n".join(str(x) for x in self.teardowns))
+            + indent("\n".join(str(x) for x in self.teardowns))
         )
     if self.matches.TryCatch:
         return (

--- a/nativepython/native_ast_to_llvm.py
+++ b/nativepython/native_ast_to_llvm.py
@@ -917,18 +917,16 @@ class FunctionConverter:
                             native_ast.Bool
                         )
 
-            for py_op, floatop, intop_s, intop_u in [
-                        ('Add', 'fadd', 'add', 'add'),
-                        ('Mul', 'fmul', 'mul', 'mul'),
-                        ('Div', 'fdiv', 'sdiv', 'udiv'),
-                        ('Mod', 'frem', 'srem', 'urem'),
-                        ('Sub', 'fsub', 'sub', 'sub'),
-                        ('LShift', None, 'shl', 'shl'),
-                        ('RShift', None, 'ashr', 'lshr'),
-                        ('BitOr', None, 'or_', 'or_'),
-                        ('BitXor', None, 'xor', 'xor'),
-                        ('BitAnd', None, 'and_', 'and_')
-            ]:
+            for py_op, floatop, intop_s, intop_u in [('Add', 'fadd', 'add', 'add'),
+                                                     ('Mul', 'fmul', 'mul', 'mul'),
+                                                     ('Div', 'fdiv', 'sdiv', 'udiv'),
+                                                     ('Mod', 'frem', 'srem', 'urem'),
+                                                     ('Sub', 'fsub', 'sub', 'sub'),
+                                                     ('LShift', None, 'shl', 'shl'),
+                                                     ('RShift', None, 'ashr', 'lshr'),
+                                                     ('BitOr', None, 'or_', 'or_'),
+                                                     ('BitXor', None, 'xor', 'xor'),
+                                                     ('BitAnd', None, 'and_', 'and_')]:
                 if getattr(expr.op.matches, py_op):
                     assert l.native_type == r.native_type, \
                         "malformed types: expect l&r to be the same but got %s,%s,%s\n\nexpr=%s"\
@@ -1181,7 +1179,7 @@ class Converter(object):
             arg_assignments = {}
             for i in range(len(func.args)):
                 arg_assignments[definition.args[i][0]] = \
-                        TypedLLVMValue(func.args[i], definition.args[i][1])
+                    TypedLLVMValue(func.args[i], definition.args[i][1])
 
             block = func.append_basic_block('entry')
             builder = llvmlite.ir.IRBuilder(block)

--- a/nativepython/native_ast_to_llvm.py
+++ b/nativepython/native_ast_to_llvm.py
@@ -930,7 +930,7 @@ class FunctionConverter:
                 if getattr(expr.op.matches, py_op):
                     assert l.native_type == r.native_type, \
                         "malformed types: expect l&r to be the same but got %s,%s,%s\n\nexpr=%s"\
-                            % (py_op, l.native_type, r.native_type, expr)
+                        % (py_op, l.native_type, r.native_type, expr)
                     if l.native_type.matches.Float and floatop is not None:
                         return TypedLLVMValue(
                             getattr(self.builder, floatop)(l.llvm_value, r.llvm_value),

--- a/nativepython/native_ast_to_llvm.py
+++ b/nativepython/native_ast_to_llvm.py
@@ -1209,7 +1209,7 @@ class Converter(object):
                     if not builder.block.is_terminated:
                         builder.unreachable()
 
-            except Exception as e:
+            except Exception:
                 print("function failing = " + name)
                 raise
 

--- a/nativepython/native_ast_to_llvm_test.py
+++ b/nativepython/native_ast_to_llvm_test.py
@@ -44,11 +44,13 @@ class TestNativeAstToLlvm(unittest.TestCase):
             output_type=Void,
             body=FunctionBody.Internal(
                 Expression.Finally(
-                    expr=ct.call() >>
+                    expr=(
+                        ct.call() >>
                         Expression.ActivatesTeardown('a1') >>
                         ct.call() >>
                         Expression.ActivatesTeardown('a2') >>
-                        nullExpr,
+                        nullExpr
+                    ),
                     teardowns=[
                         Teardown.ByTag(tag='a1', expr=Expression.Branch(cond=const_int32_expr(10), true=ct.call(), false=nullExpr)),
                         Teardown.ByTag(tag='a1', expr=nullExpr)

--- a/nativepython/python_to_native_converter.py
+++ b/nativepython/python_to_native_converter.py
@@ -258,8 +258,6 @@ class PythonToNativeConverter(object):
         if identifier in self._names_for_identifier:
             return self._names_for_identifier[identifier]
 
-        underlyingDefinition = self._definitions[callTarget.name]
-
         args = []
         for i in range(len(callTarget.input_types)):
             if not callTarget.input_types[i].is_empty:

--- a/nativepython/python_to_native_converter.py
+++ b/nativepython/python_to_native_converter.py
@@ -23,10 +23,9 @@ from nativepython.typed_expression import TypedExpression
 from nativepython.conversion_exception import ConversionException
 from nativepython.expression_conversion_context import ExpressionConversionContext
 from nativepython.function_conversion_context import FunctionConversionContext, FunctionOutput
+from typed_python import *
 
 NoneExprType = NoneWrapper()
-
-from typed_python import *
 
 typeWrapper = lambda t: nativepython.python_object_representation.typedPythonTypeToTypeWrapper(t)
 

--- a/nativepython/python_to_native_converter.py
+++ b/nativepython/python_to_native_converter.py
@@ -66,8 +66,8 @@ class NativeFunctionConversionContext:
             outputArg = None
 
         inputArgs = [subcontext.inputArg(input_types[i], 'a_%s' % i) if not input_types[i].is_empty
-                        else subcontext.pushPod(native_ast.nullExpr, input_types[i])
-                        for i in range(len(input_types))]
+                     else subcontext.pushPod(native_ast.nullExpr, input_types[i])
+                     for i in range(len(input_types))]
 
         native_input_types = [t.getNativePassingType() for t in input_types if not t.is_empty]
 

--- a/nativepython/python_to_native_converter.py
+++ b/nativepython/python_to_native_converter.py
@@ -80,8 +80,10 @@ class NativeFunctionConversionContext:
 
         generatingFunction(subcontext, outputArg, *inputArgs)
 
-        native_args = [('a_%s' % i, input_types[i].getNativePassingType())
-            for i in range(len(input_types)) if not input_types[i].is_empty]
+        native_args = [
+            ('a_%s' % i, input_types[i].getNativePassingType())
+            for i in range(len(input_types)) if not input_types[i].is_empty
+        ]
         if output_type.is_pass_by_ref:
             native_args = [('.return', output_type.getNativePassingType())] + native_args
 

--- a/nativepython/tests/alternative_compilation_test.py
+++ b/nativepython/tests/alternative_compilation_test.py
@@ -39,7 +39,8 @@ class TestAlternativeCompilation(unittest.TestCase):
         self.assertEqual(f(Simple.C()), Simple.C())
 
     def test_complex_alternative_passing(self):
-        Complex = Alternative("Complex",
+        Complex = Alternative(
+            "Complex",
             A={'a': str, 'b': int},
             B={'a': str, 'c': int},
             C={'a': str, 'd': lambda: Complex}
@@ -115,7 +116,8 @@ class TestAlternativeCompilation(unittest.TestCase):
     def test_matching_recursively(self):
         @TypeFunction
         def Tree(T):
-            return Alternative("Tree",
+            return Alternative(
+                "Tree",
                 Leaf={'value': T},
                 Node={'left': Tree(T), 'right': Tree(T)}
             )

--- a/nativepython/tests/arithmetic_compilation_test.py
+++ b/nativepython/tests/arithmetic_compilation_test.py
@@ -118,8 +118,8 @@ class TestArithmeticCompilation(unittest.TestCase):
         successes = 0
 
         for f in [add, sub, mul, div, mod, lshift, rshift,
-                    pow, bitxor, bitand, bitor, less,
-                    greater, lessEq, greaterEq, eq, neq]:
+                  pow, bitxor, bitand, bitor, less,
+                  greater, lessEq, greaterEq, eq, neq]:
             if f in [pow]:
                 lvals = range(-5, 5)
                 rvals = range(5)

--- a/nativepython/tests/const_dict_compilation_test.py
+++ b/nativepython/tests/const_dict_compilation_test.py
@@ -55,7 +55,7 @@ class TestConstDictCompilation(unittest.TestCase):
         for dtype in dictTypes:
             @Compiled
             def copyInOut(x: dtype):
-                y = x
+                _ = x
                 return x
 
             aDict = makeSomeValues(dtype)
@@ -81,7 +81,7 @@ class TestConstDictCompilation(unittest.TestCase):
             def callOrExpr(f):
                 try:
                     return ("Value", f())
-                except Exception as e:
+                except Exception:
                     return ("Exception", )
 
             d = makeSomeValues(dtype, 10)

--- a/nativepython/tests/list_of_compilation_test.py
+++ b/nativepython/tests/list_of_compilation_test.py
@@ -129,7 +129,7 @@ class TestListOfCompilation(unittest.TestCase):
 
             self.assertEqual(_types.refcount(intTup), 2)
 
-            res = None
+            res = None  # noqa
 
             self.assertEqual(_types.refcount(intTup), 1)
 

--- a/nativepython/tests/multithreading_test.py
+++ b/nativepython/tests/multithreading_test.py
@@ -58,11 +58,11 @@ class TestMultithreading(unittest.TestCase):
             return res
 
         ratios = []
-        for _ in range(10):
+        for _1 in range(10):
             t0 = time.time()
-            res1 = thread_apply(f, [(100000000,)])
+            thread_apply(f, [(100000000,)])
             t1 = time.time()
-            res2 = thread_apply(f, [(100000000,), (100000001,)])
+            thread_apply(f, [(100000000,), (100000001,)])
             t2 = time.time()
 
             first = t1 - t0
@@ -84,7 +84,7 @@ class TestMultithreading(unittest.TestCase):
     def test_refcounts_of_objects_across_boundary(self):
         class Object:
             pass
-        anObject = Object()
+        _ = Object()
 
         A = Alternative("A", X={'x': int}, Y={'y': int})
 
@@ -104,9 +104,9 @@ class TestMultithreading(unittest.TestCase):
 
         @Compiled
         def rapidlyIncAndDecref(x: typeOfInstance):
-            y = x
-            for _ in range(1000000):
-                y = x
+            _ = x
+            for _1 in range(1000000):
+                _ = x
             return x
 
         thread_apply(rapidlyIncAndDecref, [(instance,)] * 10)

--- a/nativepython/tests/tuple_of_compilation_test.py
+++ b/nativepython/tests/tuple_of_compilation_test.py
@@ -128,7 +128,7 @@ class TestTupleOfCompilation(unittest.TestCase):
 
             self.assertEqual(_types.refcount(intTup), 2)
 
-            res = None
+            res = None  # noqa
 
             self.assertEqual(_types.refcount(intTup), 1)
 

--- a/nativepython/type_wrappers/bound_compiled_method_wrapper.py
+++ b/nativepython/type_wrappers/bound_compiled_method_wrapper.py
@@ -56,9 +56,9 @@ class BoundCompiledMethodWrapper(Wrapper):
         clsType = self.wrapped_type
 
         return self.wrapped_type.convert_method_call(
-                context,
-                left.changeType(self.wrapped_type),
-                self.method_name,
-                args,
-                kwargs
+            context,
+            left.changeType(self.wrapped_type),
+            self.method_name,
+            args,
+            kwargs
         )

--- a/nativepython/type_wrappers/bound_compiled_method_wrapper.py
+++ b/nativepython/type_wrappers/bound_compiled_method_wrapper.py
@@ -53,8 +53,6 @@ class BoundCompiledMethodWrapper(Wrapper):
         )
 
     def convert_call(self, context, left, args, kwargs):
-        clsType = self.wrapped_type
-
         return self.wrapped_type.convert_method_call(
             context,
             left.changeType(self.wrapped_type),

--- a/nativepython/type_wrappers/bytes_wrapper.py
+++ b/nativepython/type_wrappers/bytes_wrapper.py
@@ -50,8 +50,9 @@ class BytesWrapper(RefcountedWrapper):
     def convert_bin_op(self, context, left, op, right):
         if right.expr_type == left.expr_type:
             if op.matches.Add:
-                return context.push(bytes, lambda bytesRef:
-                    bytesRef.expr.store(
+                return context.push(
+                    bytes,
+                    lambda bytesRef: bytesRef.expr.store(
                         runtime_functions.bytes_concat.call(
                             left.nonref_expr.cast(VoidPtr),
                             right.nonref_expr.cast(VoidPtr)
@@ -92,8 +93,9 @@ class BytesWrapper(RefcountedWrapper):
         return context.pushPod(int, self.convert_len_native(expr.nonref_expr))
 
     def constant(self, context, s):
-        return context.push(bytes, lambda bytesRef:
-            bytesRef.expr.store(
+        return context.push(
+            bytes,
+            lambda bytesRef: bytesRef.expr.store(
                 runtime_functions.bytes_from_ptr_and_len.call(
                     native_ast.const_bytes_cstr(s),
                     native_ast.const_int_expr(len(s))

--- a/nativepython/type_wrappers/bytes_wrapper.py
+++ b/nativepython/type_wrappers/bytes_wrapper.py
@@ -83,9 +83,9 @@ class BytesWrapper(RefcountedWrapper):
 
     def convert_len_native(self, expr):
         return native_ast.Expression.Branch(
-                cond=expr,
-                false=native_ast.const_int_expr(0),
-                true=expr.ElementPtrIntegers(0, 1).ElementPtrIntegers(4).cast(native_ast.Int32.pointer()).load().cast(native_ast.Int64)
+            cond=expr,
+            false=native_ast.const_int_expr(0),
+            true=expr.ElementPtrIntegers(0, 1).ElementPtrIntegers(4).cast(native_ast.Int32.pointer()).load().cast(native_ast.Int64)
         )
 
     def convert_len(self, context, expr):

--- a/nativepython/type_wrappers/class_wrapper.py
+++ b/nativepython/type_wrappers/class_wrapper.py
@@ -207,7 +207,8 @@ class ClassWrapper(RefcountedWrapper):
 
         # clear bits of init flags
         for byteOffset in range(self.bytesOfInitBits):
-            context.pushEffect(out.nonref_expr
+            context.pushEffect(
+                out.nonref_expr
                 .cast(native_ast.UInt8.pointer())
                 .ElementPtrIntegers(8 + byteOffset).store(native_ast.const_uint8_expr(0))
             )
@@ -230,5 +231,8 @@ class ClassWrapper(RefcountedWrapper):
             initFuncType.convert_call(context, context.pushVoid(initFuncType), (out,) + args, {})
         else:
             if len(args):
-                context.pushException(TypeError, "Can't construct a " + self.typeRepresentation.__qualname__ +
-                        " with positional arguments because it doesn't have an __init__")
+                context.pushException(
+                    TypeError,
+                    "Can't construct a " + self.typeRepresentation.__qualname__ +
+                    " with positional arguments because it doesn't have an __init__"
+                )

--- a/nativepython/type_wrappers/class_wrapper.py
+++ b/nativepython/type_wrappers/class_wrapper.py
@@ -82,9 +82,13 @@ class ClassWrapper(RefcountedWrapper):
 
     def memberPtr(self, instance, ix):
         return (
-            instance.nonref_expr.cast(native_ast.UInt8.pointer()).ElementPtrIntegers(self.indexToByteOffset[ix])
-                .cast(
-                    typeWrapper(self.typeRepresentation.MemberTypes[ix]).getNativeLayoutType().pointer()
+            instance
+            .nonref_expr.cast(native_ast.UInt8.pointer())
+            .ElementPtrIntegers(self.indexToByteOffset[ix])
+            .cast(
+                typeWrapper(self.typeRepresentation.MemberTypes[ix])
+                .getNativeLayoutType()
+                .pointer()
             )
         )
 
@@ -94,11 +98,11 @@ class ClassWrapper(RefcountedWrapper):
 
         return (
             instance.nonref_expr
-                .cast(native_ast.UInt8.pointer())
-                .ElementPtrIntegers(8 + byte)
-                .load()
-                .rshift(native_ast.const_uint8_expr(bit))
-                .bitand(native_ast.const_uint8_expr(1))
+            .cast(native_ast.UInt8.pointer())
+            .ElementPtrIntegers(8 + byte)
+            .load()
+            .rshift(native_ast.const_uint8_expr(bit))
+            .bitand(native_ast.const_uint8_expr(1))
         )
 
     def setIsInitializedExpr(self, instance, ix):
@@ -160,7 +164,7 @@ class ClassWrapper(RefcountedWrapper):
         if attr_type.is_pod:
             return context.pushEffect(
                 self.memberPtr(instance, ix).store(value.nonref_expr)
-                    >> self.setIsInitializedExpr(instance, ix)
+                >> self.setIsInitializedExpr(instance, ix)
             )
         else:
             member = context.pushReference(attr_type, self.memberPtr(instance, ix))

--- a/nativepython/type_wrappers/const_dict_wrapper.py
+++ b/nativepython/type_wrappers/const_dict_wrapper.py
@@ -80,22 +80,18 @@ class ConstDictWrapper(RefcountedWrapper):
     def convert_getkey_by_index_unsafe(self, context, expr, item):
         return context.pushReference(
             self.keyType,
-            expr.nonref_expr.ElementPtrIntegers(0, 4)
-                .elemPtr(
-                    item.nonref_expr.mul(native_ast.const_int_expr(self.kvBytecount))
-            )
-                .cast(self.keyType.getNativeLayoutType().pointer())
+            expr.nonref_expr.ElementPtrIntegers(0, 4).elemPtr(
+                item.nonref_expr.mul(native_ast.const_int_expr(self.kvBytecount))
+            ).cast(self.keyType.getNativeLayoutType().pointer())
         )
 
     def convert_getvalue_by_index_unsafe(self, context, expr, item):
         return context.pushReference(
             self.keyType,
-            expr.nonref_expr.ElementPtrIntegers(0, 4)
-                .elemPtr(
-                    item.nonref_expr.mul(native_ast.const_int_expr(self.kvBytecount))
-                        .add(native_ast.const_int_expr(self.keyBytecount))
-            )
-                .cast(self.valueType.getNativeLayoutType().pointer())
+            expr.nonref_expr.ElementPtrIntegers(0, 4).elemPtr(
+                item.nonref_expr.mul(native_ast.const_int_expr(self.kvBytecount))
+                .add(native_ast.const_int_expr(self.keyBytecount))
+            ).cast(self.valueType.getNativeLayoutType().pointer())
         )
 
     def convert_bin_op_reverse(self, context, left, op, right):

--- a/nativepython/type_wrappers/list_of_wrapper.py
+++ b/nativepython/type_wrappers/list_of_wrapper.py
@@ -73,8 +73,9 @@ class ListOfWrapper(TupleOrListOfWrapper):
                 )
 
                 if self.underlyingWrapperType.is_pass_by_ref:
-                    return context.push(self.underlyingWrapperType, lambda out:
-                        native.call(out, instance, count)
+                    return context.push(
+                        self.underlyingWrapperType,
+                        lambda out: native.call(out, instance, count)
                     )
                 else:
                     return context.pushPod(

--- a/nativepython/type_wrappers/list_of_wrapper.py
+++ b/nativepython/type_wrappers/list_of_wrapper.py
@@ -65,11 +65,11 @@ class ListOfWrapper(TupleOrListOfWrapper):
                     return
 
                 native = context.converter.defineNativeFunction(
-                            'pop(' + self.typeRepresentation.__name__ + ")",
-                            ('util', self, 'pop'),
-                            [self, int],
-                            self.underlyingWrapperType,
-                            self.generatePop
+                    'pop(' + self.typeRepresentation.__name__ + ")",
+                    ('util', self, 'pop'),
+                    [self, int],
+                    self.underlyingWrapperType,
+                    self.generatePop
                 )
 
                 if self.underlyingWrapperType.is_pass_by_ref:

--- a/nativepython/type_wrappers/pointer_to_wrapper.py
+++ b/nativepython/type_wrappers/pointer_to_wrapper.py
@@ -88,10 +88,11 @@ class PointerToWrapper(Wrapper):
 
             left = left.toInt64()
 
-            return context.pushPod(int,
+            return context.pushPod(
+                int,
                 left.nonref_expr
-                    .sub(right.nonref_expr)
-                    .div(typeWrapper(self.typeRepresentation.ElementType).getBytecount())
+                .sub(right.nonref_expr)
+                .div(typeWrapper(self.typeRepresentation.ElementType).getBytecount())
             )
 
         if op.matches.Lt and right.expr_type == left.expr_type:

--- a/nativepython/type_wrappers/range_wrapper.py
+++ b/nativepython/type_wrappers/range_wrapper.py
@@ -83,7 +83,8 @@ class RangeIteratorWrapper(Wrapper):
                 expr.expr.ElementPtrIntegers(0, 0).load().add(1)
             )
         )
-        canContinue = context.pushPod(bool,
+        canContinue = context.pushPod(
+            bool,
             expr.expr.ElementPtrIntegers(0, 0).load().lt(
                 expr.expr.ElementPtrIntegers(0, 1).load()
             )

--- a/nativepython/type_wrappers/refcounted_wrapper.py
+++ b/nativepython/type_wrappers/refcounted_wrapper.py
@@ -56,9 +56,11 @@ class RefcountedWrapper(Wrapper):
             native_ast.Expression.Branch(
                 cond=other,
                 false=expr.store(other),
-                true=expr.store(other) >>
+                true=(
+                    expr.store(other) >>
                     expr.load().ElementPtrIntegers(0, 0).atomic_add(1) >>
                     native_ast.nullExpr
+                )
             )
         )
 

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -89,8 +89,9 @@ class StringWrapper(RefcountedWrapper):
                     )
 
             if op.matches.Add:
-                return context.push(str, lambda strRef:
-                    strRef.expr.store(
+                return context.push(
+                    str,
+                    lambda strRef: strRef.expr.store(
                         runtime_functions.string_concat.call(
                             left.nonref_expr.cast(VoidPtr),
                             right.nonref_expr.cast(VoidPtr)
@@ -109,10 +110,12 @@ class StringWrapper(RefcountedWrapper):
             with true:
                 context.pushException(IndexError, "string index out of range")
 
-        return context.push(str, lambda strRef:
-            strRef.expr.store(
-                runtime_functions.string_getitem_int64.call(expr.nonref_expr.cast(native_ast.VoidPtr), item.nonref_expr)
-                .cast(self.layoutType)
+        return context.push(
+            str,
+            lambda strRef: strRef.expr.store(
+                runtime_functions.string_getitem_int64.call(
+                    expr.nonref_expr.cast(native_ast.VoidPtr), item.nonref_expr
+                ).cast(self.layoutType)
             )
         )
 
@@ -127,8 +130,9 @@ class StringWrapper(RefcountedWrapper):
         return context.pushPod(int, self.convert_len_native(expr.nonref_expr))
 
     def constant(self, context, s):
-        return context.push(str, lambda strRef:
-            strRef.expr.store(
+        return context.push(
+            str,
+            lambda strRef: strRef.expr.store(
                 runtime_functions.string_from_utf8_and_len.call(
                     native_ast.const_utf8_cstr(s),
                     native_ast.const_int_expr(len(s))

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -112,7 +112,7 @@ class StringWrapper(RefcountedWrapper):
         return context.push(str, lambda strRef:
             strRef.expr.store(
                 runtime_functions.string_getitem_int64.call(expr.nonref_expr.cast(native_ast.VoidPtr), item.nonref_expr)
-                    .cast(self.layoutType)
+                .cast(self.layoutType)
             )
         )
 

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -118,9 +118,9 @@ class StringWrapper(RefcountedWrapper):
 
     def convert_len_native(self, expr):
         return native_ast.Expression.Branch(
-                cond=expr,
-                false=native_ast.const_int_expr(0),
-                true=expr.ElementPtrIntegers(0, 1).ElementPtrIntegers(4).cast(native_ast.Int32.pointer()).load().cast(native_ast.Int64)
+            cond=expr,
+            false=native_ast.const_int_expr(0),
+            true=expr.ElementPtrIntegers(0, 1).ElementPtrIntegers(4).cast(native_ast.Int32.pointer()).load().cast(native_ast.Int64)
         )
 
     def convert_len(self, context, expr):

--- a/nativepython/type_wrappers/tuple_of_wrapper.py
+++ b/nativepython/type_wrappers/tuple_of_wrapper.py
@@ -112,8 +112,8 @@ class TupleOrListOfWrapper(RefcountedWrapper):
             out.expr.load().ElementPtrIntegers(0, 4).store(
                 runtime_functions.malloc.call(
                     left_size.nonref_expr
-                        .add(right_size.nonref_expr)
-                        .mul(native_ast.const_int_expr(self.underlyingWrapperType.getBytecount()))
+                    .add(right_size.nonref_expr)
+                    .mul(native_ast.const_int_expr(self.underlyingWrapperType.getBytecount()))
                 ).cast(native_ast.UInt8Ptr)
             ) >>
             out.expr.load().ElementPtrIntegers(0, 0).store(native_ast.const_int_expr(1)) >>

--- a/nativepython/type_wrappers/tuple_of_wrapper.py
+++ b/nativepython/type_wrappers/tuple_of_wrapper.py
@@ -154,9 +154,9 @@ class TupleOrListOfWrapper(RefcountedWrapper):
 
     def convert_len_native(self, expr):
         return native_ast.Expression.Branch(
-                cond=expr,
-                false=native_ast.const_int_expr(0),
-                true=expr.ElementPtrIntegers(0, 2).load().cast(native_ast.Int64)
+            cond=expr,
+            false=native_ast.const_int_expr(0),
+            true=expr.ElementPtrIntegers(0, 2).load().cast(native_ast.Int64)
         )
 
     def convert_len(self, context, expr):

--- a/nativepython/type_wrappers/wrapper.py
+++ b/nativepython/type_wrappers/wrapper.py
@@ -168,11 +168,11 @@ class Wrapper(object):
         if expr.expr_type == self:
             return expr
         return context.pushTerminal(
-            generateThrowException(context,
+            generateThrowException(
+                context,
                 TypeError("Can't convert from type %s to type %s" % (
-                    expr.expr_type.typeRepresentation.__name__,
-                    self.typeRepresentation.__name__)
-                )
+                          expr.expr_type.typeRepresentation.__name__,
+                          self.typeRepresentation.__name__))
             )
         )
 
@@ -181,8 +181,11 @@ class Wrapper(object):
 
     def convert_bin_op_reverse(self, context, r, op, l):
         return context.pushTerminal(
-            generateThrowException(context, TypeError("Can't apply op %s to expressions of type %s and %s" %
-                (op, str(l.expr_type), str(r.expr_type))))
+            generateThrowException(
+                context,
+                TypeError("Can't apply op %s to expressions of type %s and %s" %
+                          (op, str(l.expr_type), str(r.expr_type)))
+            )
         )
 
     def convert_type_call(self, context, typeInst, args, kwargs):
@@ -198,9 +201,14 @@ class Wrapper(object):
         )
 
     def convert_method_call(self, context, instance, methodname, args, kwargs):
-        return context.pushException(TypeError, "Can't call %s.%s with args of type (%s)" % (
-            self,
-            methodname,
-            ",".join([str(a.expr_type) for a in args] +
-                ["%s=%s" % (k, str(v.expr_type)) for k, v in kwargs.items()])
-        ))
+        return context.pushException(
+            TypeError,
+            "Can't call %s.%s with args of type (%s)" % (
+                self,
+                methodname,
+                ",".join(
+                    [str(a.expr_type) for a in args] +
+                    ["%s=%s" % (k, str(v.expr_type)) for k, v in kwargs.items()]
+                )
+            )
+        )

--- a/object_database/database_connection.py
+++ b/object_database/database_connection.py
@@ -556,7 +556,7 @@ class DatabaseConnection:
             self.addSchema(type(t).__schema__)
         self.subscribeMultiple([
             (type(t).__schema__.name, type(t).__qualname__, ("_identity", t._identity), False)
-                for t in objects
+            for t in objects
         ])
 
     def _lazinessForType(self, typeObj, desiredLaziness):
@@ -805,8 +805,8 @@ class DatabaseConnection:
             with self._lock:
                 try:
                     self._transaction_callbacks.pop(msg.transaction_guid)(
-                        TransactionResult.Success() if msg.success
-                            else TransactionResult.RevisionConflict(key=msg.badKey)
+                        TransactionResult.Success() if msg.success else
+                        TransactionResult.RevisionConflict(key=msg.badKey)
                     )
                 except Exception:
                     self._logger.error(

--- a/object_database/database_connection.py
+++ b/object_database/database_connection.py
@@ -343,14 +343,9 @@ class ManyVersionedObjects:
         else:
             lowestId = curTransactionId
 
-        t0 = time.time()
-
         if self._version_number_objects:
             while min(self._version_number_objects) < lowestId:
                 toCollapse = min(self._version_number_objects)
-
-                t1 = time.time()
-                count = len(self._version_number_objects[toCollapse])
 
                 for key in self._version_number_objects[toCollapse]:
                     if key not in self._versioned_objects:
@@ -734,7 +729,7 @@ class DatabaseConnection:
         return not self._suppressKey(object._identity)
 
     def _suppressKey(self, k):
-        keyname = schema, typename, ident, fieldname = keymapping.split_data_key(k)
+        schema, typename, ident, fieldname = keymapping.split_data_key(k)
 
         subscriptionSet = self._schema_and_typename_to_subscription_set.get((schema, typename))
 

--- a/object_database/database_connection.py
+++ b/object_database/database_connection.py
@@ -907,12 +907,17 @@ class DatabaseConnection:
 
         elif msg.matches.SubscriptionComplete:
             with self._lock:
-                event = self._pendingSubscriptions.get((msg.schema, msg.typename,
-                    tuple(msg.fieldname_and_value) if msg.fieldname_and_value is not None else None))
+                event = self._pendingSubscriptions.get((
+                    msg.schema,
+                    msg.typename,
+                    tuple(msg.fieldname_and_value) if msg.fieldname_and_value is not None else None
+                ))
 
                 if not event:
-                    self._logger.error("Received unrequested subscription to schema %s / %s / %s. have %s",
-                        msg.schema, msg.typename, msg.fieldname_and_value, self._pendingSubscriptions)
+                    self._logger.error(
+                        "Received unrequested subscription to schema %s / %s / %s. have %s",
+                        msg.schema, msg.typename, msg.fieldname_and_value, self._pendingSubscriptions
+                    )
                     return
 
                 lookupTuple = (msg.schema, msg.typename, msg.fieldname_and_value)
@@ -1105,8 +1110,11 @@ class DatabaseConnection:
             out_writes[k] = v.serializedByteRep.hex() if v.serializedByteRep is not None else None
             if len(out_writes) > 10000:
                 self._channel.write(
-                    ClientToServer.TransactionData(writes=out_writes, set_adds={}, set_removes={},
-                        key_versions=(), index_versions=(), transaction_guid=transaction_guid)
+                    ClientToServer.TransactionData(
+                        writes=out_writes, set_adds={}, set_removes={},
+                        key_versions=(), index_versions=(),
+                        transaction_guid=transaction_guid
+                    )
                 )
                 self._channel.write(ClientToServer.Heartbeat())
                 out_writes = {}
@@ -1119,8 +1127,11 @@ class DatabaseConnection:
 
             if len(out_set_adds) > 10000 or ct > 100000:
                 self._channel.write(
-                    ClientToServer.TransactionData(writes={}, set_adds=out_set_adds, set_removes={},
-                        key_versions=(), index_versions=(), transaction_guid=transaction_guid)
+                    ClientToServer.TransactionData(
+                        writes={}, set_adds=out_set_adds, set_removes={},
+                        key_versions=(), index_versions=(),
+                        transaction_guid=transaction_guid
+                    )
                 )
                 self._channel.write(ClientToServer.Heartbeat())
                 out_set_adds = {}
@@ -1134,8 +1145,11 @@ class DatabaseConnection:
 
             if len(out_set_removes) > 10000 or ct > 100000:
                 self._channel.write(
-                    ClientToServer.TransactionData(writes={}, set_adds={}, set_removes=out_set_removes,
-                        key_versions=(), index_versions=(), transaction_guid=transaction_guid)
+                    ClientToServer.TransactionData(
+                        writes={}, set_adds={}, set_removes=out_set_removes,
+                        key_versions=(), index_versions=(),
+                        transaction_guid=transaction_guid
+                    )
                 )
                 self._channel.write(ClientToServer.Heartbeat())
                 out_set_removes = {}
@@ -1144,8 +1158,11 @@ class DatabaseConnection:
         keys_to_check_versions = list(keys_to_check_versions)
         while len(keys_to_check_versions) > 10000:
             self._channel.write(
-                ClientToServer.TransactionData(writes={}, set_adds={}, set_removes={},
-                    key_versions=keys_to_check_versions[:10000], index_versions=(), transaction_guid=transaction_guid)
+                ClientToServer.TransactionData(
+                    writes={}, set_adds={}, set_removes={},
+                    key_versions=keys_to_check_versions[:10000],
+                    index_versions=(), transaction_guid=transaction_guid
+                )
             )
             self._channel.write(ClientToServer.Heartbeat())
             keys_to_check_versions = keys_to_check_versions[10000:]
@@ -1153,8 +1170,10 @@ class DatabaseConnection:
         indices_to_check_versions = list(indices_to_check_versions)
         while len(indices_to_check_versions) > 10000:
             self._channel.write(
-                ClientToServer.TransactionData(writes={}, set_adds={}, set_removes={},
-                    key_versions=(), index_versions=indices_to_check_versions[:10000], transaction_guid=transaction_guid)
+                ClientToServer.TransactionData(
+                    writes={}, set_adds={}, set_removes={},
+                    key_versions=(), index_versions=indices_to_check_versions[:10000],
+                    transaction_guid=transaction_guid)
             )
             indices_to_check_versions = indices_to_check_versions[10000:]
 

--- a/object_database/database_ring_invariant_test.py
+++ b/object_database/database_ring_invariant_test.py
@@ -107,7 +107,7 @@ class RingInvariantTest(unittest.TestCase):
 
         with db.transaction():
             # create the empty ring
-            r = Ring.New()
+            Ring.New()
 
         def writeSome():
             with db.transaction():

--- a/object_database/database_test.py
+++ b/object_database/database_test.py
@@ -55,7 +55,8 @@ class BlockingCallback:
         self.is_released.put(True)
 
 
-expr = Alternative("Expr",
+expr = Alternative(
+    "Expr",
     Constant={'value': int},
     # Add = {'l': expr, 'r': expr},
     # Sub = {'l': expr, 'r': expr},

--- a/object_database/frontends/database_server.py
+++ b/object_database/frontends/database_server.py
@@ -29,8 +29,10 @@ def main(argv):
 
     parser.add_argument("host")
     parser.add_argument("port", type=int)
-    parser.add_argument("--service-token", type=str, required=True,
-        help="the auth token to be used with this service")
+    parser.add_argument(
+        "--service-token", type=str, required=True,
+        help="the auth token to be used with this service"
+    )
     parser.add_argument("--ssl-path", default=None, required=False, help="path to (self-signed) SSL certificate")
     parser.add_argument("--redis_port", type=int, default=None)
     parser.add_argument("--inmem", default=False, action='store_true')

--- a/object_database/frontends/database_throughput_test.py
+++ b/object_database/frontends/database_throughput_test.py
@@ -26,8 +26,10 @@ def main(argv):
 
     parser.add_argument("host")
     parser.add_argument("port")
-    parser.add_argument("--service-token", type=str, required=True,
-        help="the auth token to be used with this service")
+    parser.add_argument(
+        "--service-token", type=str, required=True,
+        help="the auth token to be used with this service"
+    )
     parser.add_argument("seconds", type=float)
     parser.add_argument("--threads", dest='threads', type=int, default=1)
 

--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -70,8 +70,8 @@ def main(argv=None):
             ActiveWebService.configureFromCommandline(
                 database, service,
                 ['--port', '8000',
-                '--host', '0.0.0.0',
-                '--log-level', 'INFO']
+                 '--host', '0.0.0.0',
+                 '--log-level', 'INFO']
             )
 
             ActiveWebService.setLoginPlugin(

--- a/object_database/frontends/service_config.py
+++ b/object_database/frontends/service_config.py
@@ -117,7 +117,7 @@ def _main(argv):
                 svcClass = s.instantiateServiceType()
 
             svcClass.configureFromCommandline(db, s, parsedArgs.args)
-        except Exception as e:
+        except Exception:
             traceback.print_exc()
             return 1
 

--- a/object_database/frontends/service_manager.py
+++ b/object_database/frontends/service_manager.py
@@ -42,8 +42,10 @@ def main(argv=None):
     parser.add_argument("port", type=int)
     parser.add_argument("--source", help="path for the source trees used by services", required=True)
     parser.add_argument("--storage", help="path for local storage used by services", required=True)
-    parser.add_argument("--service-token", type=str, required=True,
-        help="the auth token to be used with this service")
+    parser.add_argument(
+        "--service-token", type=str, required=True,
+        help="the auth token to be used with this service"
+    )
     parser.add_argument("--run_db", default=False, action='store_true')
 
     parser.add_argument("--ssl-path", default=None, required=False, help="path to (self-signed) SSL certificate")
@@ -73,9 +75,10 @@ def main(argv=None):
         parser.print_help()
         return 2
 
-    logger.info("ServiceManager on %s connecting to %s:%s",
-        parsedArgs.own_hostname, parsedArgs.db_hostname, parsedArgs.port)
-
+    logger.info(
+        "ServiceManager on %s connecting to %s:%s",
+        parsedArgs.own_hostname, parsedArgs.db_hostname, parsedArgs.port
+    )
     shouldStop = threading.Event()
 
     def shutdownCleanly(signalNumber, frame):

--- a/object_database/schema.py
+++ b/object_database/schema.py
@@ -47,8 +47,9 @@ class Schema:
 
     def toDefinition(self):
         return SchemaDefinition({
-            tname: self.typeToDef(t) for tname, t in self._types.items()
-                if issubclass(t, DatabaseObject)
+            tname: self.typeToDef(t)
+            for tname, t in self._types.items()
+            if issubclass(t, DatabaseObject)
         })
 
     def __repr__(self):

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -427,8 +427,6 @@ class Server:
                         )
                         return True
 
-                    t1 = time.time()
-
                     self._pendingSubscriptionRecheck = []
 
                 # we need to send everything we know about 'identities', keeping in mind that we have to
@@ -436,7 +434,6 @@ class Server:
                 # in the new set
                 identities_left_to_send = set(identities)
 
-                done = False
                 messageCount = 0
                 while True:
                     locktime_start = time.time()
@@ -593,7 +590,7 @@ class Server:
         if checkPending:
             for transactionMessage in self._pendingSubscriptionRecheck:
                 for key in transactionMessage.writes:
-                    val = transactionMessage.writes[key]
+                    transactionMessage.writes[key]
 
                     # if we write to a key we've already sent, we'll need to resend it
                     identity = keymapping.split_data_key(key)[2]
@@ -957,7 +954,7 @@ class Server:
                 channelsTriggered.update(self._id_to_channel[i])
 
         for channel in channelsTriggeredForPriors:
-            lazy_message = ServerToClient.LazyTransactionPriors(writes=priorValues)
+            lazy_message = ServerToClient.LazyTransactionPriors(writes=priorValues)  # noqa
 
         transaction_message = ServerToClient.Transaction(
             writes={k: v for k, v in key_value.items()},

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -973,7 +973,8 @@ class Server:
             channel.sendTransaction(transaction_message)
 
         if self.verbose or time.time() - t0 > self.longTransactionThreshold:
-            self._logger.info("Transaction [%.2f/%.2f/%.2f] with %s writes, %s set ops: %s",
+            self._logger.info(
+                "Transaction [%.2f/%.2f/%.2f] with %s writes, %s set ops: %s",
                 t1 - t0, t2 - t1, time.time() - t2,
                 len(key_value), len(set_adds) + len(set_removes), sorted(key_value)[:3]
             )

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -324,7 +324,7 @@ class Server:
     def _handleSubscriptionInForeground(self, channel, msg):
         # first see if this would be an easy subscription to handle
         with Timer("Handle subscription in foreground: %s/%s/%s/isLazy=%s over %s",
-                    msg.schema, msg.typename, msg.fieldname_and_value, msg.isLazy, lambda: len(identities)):
+                   msg.schema, msg.typename, msg.fieldname_and_value, msg.isLazy, lambda: len(identities)):
             typedef, identities = self._parseSubscriptionMsg(channel, msg)
 
             if not (msg.isLazy and len(identities) < self.MAX_LAZY_TO_SEND_SYNCHRONOUSLY or len(identities) < self.MAX_NORMAL_TO_SEND_SYNCHRONOUSLY):
@@ -539,7 +539,7 @@ class Server:
 
         for fieldname in typedef.indices:
             keys = [keymapping.data_reverse_index_key(schema_name, typename, identity, fieldname)
-                            for identity in identities]
+                    for identity in identities]
 
             vals = self._kvstore.getSeveral(keys)
 
@@ -616,7 +616,7 @@ class Server:
 
         for fieldname in typedef.fields:
             keys = [keymapping.data_key_from_names(schema_name, typename, identity, fieldname)
-                            for identity in to_send]
+                    for identity in to_send]
 
             vals = self._kvstore.getSeveral(keys)
 

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -574,17 +574,16 @@ class Server:
 
             connectedChannel.subscribedTypes[(schema, typename)] = -1 if not isLazy else self._cur_transaction_num
 
-    def _sendPartialSubscription(
-                self,
-                connectedChannel,
-                schema_name,
-                typename,
-                fieldname_and_value,
-                typedef,
-                identities,
-                identities_left_to_send,
-                BATCH_SIZE=100,
-                checkPending=True):
+    def _sendPartialSubscription(self,
+                                 connectedChannel,
+                                 schema_name,
+                                 typename,
+                                 fieldname_and_value,
+                                 typedef,
+                                 identities,
+                                 identities_left_to_send,
+                                 BATCH_SIZE=100,
+                                 checkPending=True):
 
         # get some objects to send
         kvs = {}

--- a/object_database/server.py
+++ b/object_database/server.py
@@ -934,10 +934,10 @@ class Server:
                 if idsToAddToTransaction:
                     self._increaseBroadcastTransactionToInclude(
                         channel,  # deliberately just using whatever random channel, under
-                                 # the assumption they're all the same. it would be better
-                                 # to explictly compute the union of the relevant set of defined fields,
-                                 # as its possible one channel has more fields for a type than another
-                                 # and we'd like to broadcast them all
+                                  # the assumption they're all the same. it would be better
+                                  # to explictly compute the union of the relevant set of
+                                  # defined fields, as its possible one channel has more fields
+                                  # for a type than another and we'd like to broadcast them all
                         index_key, idsToAddToTransaction, key_value, set_adds, set_removes)
 
         transaction_message = None

--- a/object_database/service_manager/ServiceInstance.py
+++ b/object_database/service_manager/ServiceInstance.py
@@ -266,8 +266,8 @@ class ServiceInstance:
         """Is this service instance up and intended to be up?"""
         return (
             self.state in ("Running", "Initializing", "Booting")
-                and not self.shouldShutdown
-                and (self.connection is None or self.connection.exists())
+            and not self.shouldShutdown
+            and (self.connection is None or self.connection.exists())
         )
 
     state = Indexed(OneOf("Booting", "Initializing", "Running", "Stopped", "FailedToStart", "Crashed"))

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -277,7 +277,7 @@ class ServiceManager(object):
             for service in service_schema.Service.lookupAll():
                 actual_by_service[service] = [
                     x for x in service_schema.ServiceInstance.lookupAll(service=service)
-                        if x.isActive()
+                    if x.isActive()
                 ]
 
         for service, actual_records in actual_by_service.items():

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -250,7 +250,7 @@ class ServiceManager(object):
                 self._logger.info(
                     "The following services need to be stopped because their codebases are out of date: %s",
                     "\n".join(["  " + i.service.name + "." + i._identity + ". "
-                            + str(i.service.codebase) + " != " + str(i.codebase) for i in needRedeploy])
+                              + str(i.service.codebase) + " != " + str(i.codebase) for i in needRedeploy])
                 )
 
         if needRedeploy:

--- a/object_database/service_manager/ServiceManagerTestCommon.py
+++ b/object_database/service_manager/ServiceManagerTestCommon.py
@@ -77,10 +77,9 @@ class ServiceManagerTestCommon(object):
         except subprocess.TimeoutExpired:
             pass
         else:
-            raise Exception("Failed to start service_manager (retcode:{})"
-                .format(self.server.returncode)
+            raise Exception(
+                f"Failed to start service_manager (retcode:{self.server.returncode})"
             )
-
         try:
             self.database = connect("localhost", 8023, self.token, retry=True)
             self.database.subscribeToSchema(core_schema, service_schema, *self.schemasToSubscribeTo())

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -210,12 +210,16 @@ class GraphDisplayService(ServiceBase):
                 1000000,
                 lambda rowIx: ["(%s) ts" % rowIx, rowIx, rowIx+1, rowIx+2]
             ).width('calc(100vw - 70px)').height('calc(100vh - 150px)'),
-            Timestamps=Button("Add a point!", GraphDisplayService.addAPoint) +
-                Card(Plot(GraphDisplayService.chartData)).width(600).height(400) + Code("BYE"),
-            feigenbaum=Dropdown("Depth", [(val, depth.setter(val)) for val in [10, 50, 100, 250, 500, 750, 1000]]) +
+            Timestamps=(
+                Button("Add a point!", GraphDisplayService.addAPoint) +
+                Card(Plot(GraphDisplayService.chartData)).width(600).height(400) + Code("BYE")
+            ),
+            feigenbaum=(
+                Dropdown("Depth", [(val, depth.setter(val)) for val in [10, 50, 100, 250, 500, 750, 1000]]) +
                 Dropdown("Polynomial", [1.0, 1.5, 2.0], lambda polyVal: setattr(Feigenbaum.lookupAny(), 'y', float(polyVal))) +
                 Dropdown("Density", list(range(100, 10000, 100)), lambda polyVal: setattr(Feigenbaum.lookupAny(), 'density', float(polyVal))) +
                 Card(Plot(lambda graph: GraphDisplayService.feigenbaum(graph, depth.get()))).width(600).height(400)
+            )
         )
 
     @staticmethod

--- a/object_database/service_manager/ServiceManager_test.py
+++ b/object_database/service_manager/ServiceManager_test.py
@@ -283,8 +283,8 @@ class HappyService(ServiceBase):
             Subscribed(lambda: Text("There are %s happy objects" % len(Happy.lookupAll()))) +
             Expands(Text("Closed"), Subscribed(lambda: HappyService.serviceDisplay(serviceObject)))
         ) + Button("go to google", "http://google.com/") + SubscribedSequence(
-                lambda: Happy.lookupAll(),
-                lambda h: Button("go to the happy", serviceObject.urlForObject(h, x=10))
+            lambda: Happy.lookupAll(),
+            lambda h: Button("go to the happy", serviceObject.urlForObject(h, x=10))
         )
 
     def doWork(self, shouldStop):

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -51,9 +51,9 @@ def parseLogfileToInstanceid(fname):
 
 class SubprocessServiceManager(ServiceManager):
     def __init__(self, ownHostname, host, port,
-                sourceDir, storageDir, serviceToken,
-                isMaster, maxGbRam=4, maxCores=4, logfileDirectory=None,
-                shutdownTimeout=None, errorLogsOnly=False):
+                 sourceDir, storageDir, serviceToken,
+                 isMaster, maxGbRam=4, maxCores=4, logfileDirectory=None,
+                 shutdownTimeout=None, errorLogsOnly=False):
         self.host = host
         self.port = port
         self.storageDir = storageDir

--- a/object_database/service_manager/Task.py
+++ b/object_database/service_manager/Task.py
@@ -85,13 +85,15 @@ class FunctionTask(TaskExecutor):
         return RunningFunctionTask(self.f)
 
 
-TaskStatusResult = Alternative('TaskStatusResult',
+TaskStatusResult = Alternative(
+    'TaskStatusResult',
     Finished={'result': object},
     Subtasks={'subtasks': ConstDict(str, TaskExecutor)},
     SleepUntil={'wakeup_timestamp': float}
 )
 
-TaskResult = Alternative("TaskResult",
+TaskResult = Alternative(
+    "TaskResult",
     Result={'result': object},
     Error={'error': str},
     Failure={}

--- a/object_database/service_manager/Task.py
+++ b/object_database/service_manager/Task.py
@@ -422,7 +422,7 @@ class TaskDispatchService(ServiceBase):
                 taskStatus.delete()
 
         elif state == "DoneCalculating":
-            with self.db.transaction() as tr:
+            with self.db.transaction():
                 parentStatus.subtasks_completed = parentStatus.subtasks_completed + 1
 
                 if len(parentStatus.subtasks) == parentStatus.subtasks_completed:

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -289,8 +289,8 @@ class AwsApi:
         results = {}
 
         for x in self.ec2_client.get_paginator('describe_spot_price_history').paginate(
-                    Filters=[{'Name': 'product-description', 'Values': ['Linux/UNIX']}],
-                    StartTime=datetime.datetime.now() - datetime.timedelta(hours=1)
+            Filters=[{'Name': 'product-description', 'Values': ['Linux/UNIX']}],
+            StartTime=datetime.datetime.now() - datetime.timedelta(hours=1)
         ):
             for record in x['SpotPriceHistory']:
                 ts = record['Timestamp']
@@ -542,11 +542,15 @@ class AwsWorkerBootService(ServiceBase):
             rendererFun=lambda s, field: cells.Subscribed(lambda:
                 s.instance_type if field == 'Instance Type' else
                 s.booted if field == 'Booted' else
-                cells.Dropdown(s.desired, [(str(ct), bootCountSetter(s, ct)) for ct in list(range(10)) + list(range(10, 101, 10))])
-                        if field == 'Desired' else
+                cells.Dropdown(
+                    s.desired,
+                    [(str(ct), bootCountSetter(s, ct)) for ct in list(range(10)) + list(range(10, 101, 10))]
+                ) if field == 'Desired' else
                 s.spot_booted if field == 'SpotBooted' else
-                cells.Dropdown(s.spot_desired, [(str(ct), bootCountSetterSpot(s, ct)) for ct in list(range(10)) + list(range(10, 101, 10))])
-                        if field == 'SpotDesired' else
+                cells.Dropdown(
+                    s.spot_desired,
+                    [(str(ct), bootCountSetterSpot(s, ct)) for ct in list(range(10)) + list(range(10, 101, 10))]
+                ) if field == 'SpotDesired' else
                 ("" if s.observedLimit is None else s.observedLimit) if field == 'ObservedLimit' else
                 ("Yes" if s.capacityConstrained else "") if field == 'CapacityConstrained' else
                 valid_instance_types[s.instance_type]['COST'] if field == 'COST' else

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -535,11 +535,18 @@ class AwsWorkerBootService(ServiceBase):
             return f
 
         return cells.Grid(
-            colFun=lambda: ['Instance Type', 'COST', 'RAM', 'CPU', 'Booted', 'Desired', 'SpotBooted', 'SpotDesired', 'ObservedLimit', 'CapacityConstrained', 'Spot-us-east-1', 'a', 'b', 'c', 'd', 'e', 'f'],
-            rowFun=lambda: sorted([x for x in State.lookupAll() if x.instance_type in instance_types_to_show], key=lambda s: s.instance_type),
+            colFun=lambda: [
+                'Instance Type', 'COST', 'RAM', 'CPU', 'Booted', 'Desired',
+                'SpotBooted', 'SpotDesired', 'ObservedLimit', 'CapacityConstrained',
+                'Spot-us-east-1', 'a', 'b', 'c', 'd', 'e', 'f'],
+            rowFun=lambda: sorted(
+                [x for x in State.lookupAll() if x.instance_type in instance_types_to_show],
+                key=lambda s: s.instance_type
+            ),
             headerFun=lambda x: x,
             rowLabelFun=None,
-            rendererFun=lambda s, field: cells.Subscribed(lambda:
+            rendererFun=lambda s, field: cells.Subscribed(
+                lambda:
                 s.instance_type if field == 'Instance Type' else
                 s.booted if field == 'Booted' else
                 cells.Dropdown(

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -160,9 +160,9 @@ valid_instance_types = {
 
 
 instance_types_to_show = set([
-    x for x in valid_instance_types if
-    ('xlarge' in x and '.xlarge' not in x) and
-     x.split(".")[0] in ['m4', 'm5', 'c4', 'c5', 'r4', 'r5', 'i3', 'g2', 'x1']
+    x for x in valid_instance_types
+    if ('xlarge' in x and '.xlarge' not in x)
+    and x.split(".")[0] in ['m4', 'm5', 'c4', 'c5', 'r4', 'r5', 'i3', 'g2', 'x1']
 ])
 
 

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -492,10 +492,10 @@ class AwsWorkerBootService(ServiceBase):
             c.max_to_boot = max_to_boot
 
     def setBootCount(self, instance_type, count):
-        state = State.lookupAny(instance_type=instType)
+        state = State.lookupAny(instance_type=instance_type)
 
         if not state:
-            state = State(instance_type=instType)
+            state = State(instance_type=instance_type)
 
         state.desired = count
 

--- a/object_database/service_manager/aws/AwsWorkerBootService.py
+++ b/object_database/service_manager/aws/AwsWorkerBootService.py
@@ -438,7 +438,6 @@ class AwsWorkerBootService(ServiceBase):
 
     @staticmethod
     def shutOneDown(instance_type):
-        api = AwsApi()
         i = [x for x in AwsApi.allRunningInstances().values() if x['InstanceType'] == instance_type]
         if not i:
             raise Exception("No instances of type %s are booted." % instance_type)

--- a/object_database/tcp_server.py
+++ b/object_database/tcp_server.py
@@ -168,7 +168,7 @@ def connect(host, port, auth_token, timeout=10.0, retry=False, eventLoop=_eventL
                 port=port,
                 ssl=ssl_ctx
             )
-        except Exception as e:
+        except Exception:
             if not retry or time.time() - t0 > timeout * .8:
                 raise
             time.sleep(min(timeout, max(timeout / 100.0, 0.01)))

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -130,8 +130,8 @@ def start_service_manager(tempDirectoryName, port, auth_token, loglevel_name="IN
     except subprocess.TimeoutExpired:
         pass
     else:
-        raise Exception("Failed to start service_manager (retcode:{})"
-            .format(server.returncode)
+        raise Exception(
+            f"Failed to start service_manager (retcode:{server.returncode})"
         )
     return server
 

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -33,8 +33,9 @@ def formatTable(rows):
     colWidth = [max([len(c) for c in col]) for col in cols]
 
     formattedRows = [
-        "  ".join(row[col] + " " * (colWidth[col] - len(row[col])) for col in range(len(cols)))
-            for row in rows
+        "  ".join(row[col] + " " * (colWidth[col] - len(row[col]))
+        for col in range(len(cols)))
+        for row in rows
     ]
     formattedRows = formattedRows[:1] + [
         "  ".join("-" * colWidth[col] for col in range(len(cols)))

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -210,7 +210,7 @@ def generateSslContext():
         cert_path = os.path.join(tempDir, 'selfsigned.cert')
         key_path = os.path.join(tempDir, 'selfsigned.key')
         try:
-            proc = subprocess.run(
+            subprocess.run(
                 [
                     'openssl', 'req', '-x509', '-newkey', 'rsa:2048',
                     '-keyout', key_path, '-nodes',

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -33,9 +33,10 @@ def formatTable(rows):
     colWidth = [max([len(c) for c in col]) for col in cols]
 
     formattedRows = [
-        "  ".join(row[col] + " " * (colWidth[col] - len(row[col]))
-        for col in range(len(cols)))
-        for row in rows
+        "  ".join(
+            row[col] + " " * (colWidth[col] - len(row[col]))
+            for col in range(len(cols))
+        ) for row in rows
     ]
     formattedRows = formattedRows[:1] + [
         "  ".join("-" * colWidth[col] for col in range(len(cols)))

--- a/object_database/view.py
+++ b/object_database/view.py
@@ -440,9 +440,11 @@ class View(object):
                 writes,
                 {k: v for k, v in self._set_adds.items() if v},
                 {k: v for k, v in self._set_removes.items() if v},
-                self._reads.union(set(writes)) if self._insistReadsConsistent
-                    else set(writes) if self._insistWritesConsistent
-                    else set(),
+                (
+                    self._reads.union(set(writes)) if self._insistReadsConsistent else
+                    set(writes) if self._insistWritesConsistent else
+                    set()
+                ),
                 self._indexReads if self._insistIndexReadsConsistent else set(),
                 tid,
                 confirmCallback

--- a/object_database/view.py
+++ b/object_database/view.py
@@ -457,7 +457,8 @@ class View(object):
                 res = result_queue.get()
 
                 if time.time() - t0 > LOG_SLOW_COMMIT_THRESHOLD:
-                    self._logger.info("Committing %s writes and %s set changes took %.1f seconds",
+                    self._logger.info(
+                        "Committing %s writes and %s set changes took %.1f seconds",
                         len(self._writes), len(self._set_adds) + len(self._set_removes), time.time() - t0
                     )
 

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -213,7 +213,6 @@ class ActiveWebService(ServiceBase):
         server.serve_forever()
 
     def configureApp(self):
-        instanceName = self.serviceObject.name
         self.app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY') or genToken()
 
         self.app.add_url_rule('/', endpoint='index', view_func=lambda: redirect("/services"))

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -258,7 +258,8 @@ class ActiveWebService(ServiceBase):
                 rowFun=lambda:
                     sorted(service_schema.Service.lookupAll(), key=lambda s: s.name),
                 headerFun=lambda x: x,
-                rendererFun=lambda s, field: Subscribed(lambda:
+                rendererFun=lambda s, field: Subscribed(
+                    lambda:
                     Clickable(s.name, "/services/" + s.name) if field == 'Service' else
                     (   Clickable(Sequence([Octicon('stop').color('red'), Span('Unlocked')]),
                                   lambda: s.lock()) if s.isUnlocked else
@@ -294,7 +295,8 @@ class ActiveWebService(ServiceBase):
                 colFun=lambda: ['Connection', 'IsMaster', 'Hostname', 'RAM ALLOCATION', 'CORE ALLOCATION', 'SERVICE COUNT', 'CPU USE', 'RAM USE'],
                 rowFun=lambda: sorted(service_schema.ServiceHost.lookupAll(), key=lambda s: s.hostname),
                 headerFun=lambda x: x,
-                rendererFun=lambda s, field: Subscribed(lambda:
+                rendererFun=lambda s, field: Subscribed(
+                    lambda:
                     s.connection._identity if field == "Connection" else
                     str(s.isMaster) if field == "IsMaster" else
                     s.hostname if field == "Hostname" else
@@ -361,8 +363,8 @@ class ActiveWebService(ServiceBase):
         return (
             HeaderBar(
                 [
-                    Subscribed(lambda:
-                        Dropdown(
+                    Subscribed(
+                        lambda: Dropdown(
                             "Service",
                             [("All", "/services")] +
                             [(s.name, "/services/" + s.name)
@@ -494,7 +496,8 @@ class ActiveWebService(ServiceBase):
 
                 lastDumpFrames += 1
                 if time.time() - lastDumpTimestamp > 5.0:
-                    self._logger.info("In the last %.2f seconds, spent %.2f seconds calculating %s messages over %s frames",
+                    self._logger.info(
+                        "In the last %.2f seconds, spent %.2f seconds calculating %s messages over %s frames",
                         time.time() - lastDumpTimestamp,
                         lastDumpTimeSpentCalculating,
                         lastDumpMessages,

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -270,12 +270,22 @@ class ActiveWebService(ServiceBase):
                     s.service_module_name if field == 'Module' else
                     s.service_class_name if field == 'Class' else
                     s.placement if field == 'Placement' else
-                    Subscribed(lambda: len(service_schema.ServiceInstance.lookupAll(service=s))) if field == 'Active' else
-                    Dropdown(s.target_count, [(str(ct), serviceCountSetter(s, ct)) for ct in serviceCounts])
-                            if field == 'TargetCount' else
+                    Subscribed(
+                        lambda: len(service_schema.ServiceInstance.lookupAll(service=s))
+                    ) if field == 'Active' else
+                    Dropdown(
+                        s.target_count,
+                        [(str(ct), serviceCountSetter(s, ct)) for ct in serviceCounts]
+                    ) if field == 'TargetCount' else
                     str(s.coresUsed) if field == 'Cores' else
                     str(s.gbRamUsed) if field == 'RAM' else
-                    (Popover(Octicon("alert"), "Failed", Traceback(s.lastFailureReason or "<Unknown>")) if s.isThrottled() else "") if field == 'Boot Status' else
+                    (
+                        Popover(
+                            Octicon("alert"),
+                            "Failed",
+                            Traceback(s.lastFailureReason or "<Unknown>")
+                        ) if s.isThrottled() else ""
+                    ) if field == 'Boot Status' else
                     ""
                 ),
                 maxRowsPerPage=50
@@ -315,7 +325,7 @@ class ActiveWebService(ServiceBase):
             if len(path) == 2:
                 return (
                     Subscribed(lambda: serviceType.serviceDisplay(serviceObj, queryArgs=queryArgs))
-                        .withSerializationContext(serviceObj.getSerializationContext())
+                    .withSerializationContext(serviceObj.getSerializationContext())
                 )
 
             typename = path[2]
@@ -333,14 +343,14 @@ class ActiveWebService(ServiceBase):
             if len(path) == 3:
                 return (
                     serviceType.serviceDisplay(serviceObj, objType=typename, queryArgs=queryArgs)
-                        .withSerializationContext(serviceObj.getSerializationContext())
+                    .withSerializationContext(serviceObj.getSerializationContext())
                 )
 
             instance = typeObj.fromIdentity(path[3])
 
             return (
                 serviceType.serviceDisplay(serviceObj, instance=instance, queryArgs=queryArgs)
-                    .withSerializationContext(serviceObj.getSerializationContext())
+                .withSerializationContext(serviceObj.getSerializationContext())
             )
 
         return Traceback("Invalid url path: %s" % path)

--- a/object_database/web/ActiveWebService_test.py
+++ b/object_database/web/ActiveWebService_test.py
@@ -125,7 +125,7 @@ class ActiveWebServiceTest(unittest.TestCase):
 
         while time.time() - t0 < timeout:
             try:
-                res = requests.get(self.base_url + "/status")
+                requests.get(self.base_url + "/status")
                 return
             except Exception:
                 time.sleep(.5)

--- a/object_database/web/LoginPlugin.py
+++ b/object_database/web/LoginPlugin.py
@@ -99,7 +99,8 @@ class LoginPluginInterface:
         if self.REQUIRED_KEYS:
             for key in self.REQUIRED_KEYS:
                 if key not in config:
-                    raise Exception("{cls} missing configuration parameter '{key}'"
+                    raise Exception(
+                        "{cls} missing configuration parameter '{key}'"
                         .format(cls=self.__class__.__name__, key=key)
                     )
                 setattr(self, '_' + key, config[key])
@@ -179,9 +180,7 @@ class LoginIpPlugin(LoginPluginInterface):
                 "" (empty string) if no error occurred and an error message otherwise
         """
         login_ip = request_ip_address()
-        self._logger.info("User '{username}' trying to authenticate from IP {login_ip}".
-            format(username=username, login_ip=login_ip)
-        )
+        self._logger.info(f"User '{username}' trying to authenticate from IP {login_ip}")
         # error = self.authenticate(username, password, login_ip=login_ip)
         if not self.bypassAuth:
             error = self._auth_plugin.authenticate(username, password)

--- a/object_database/web/LoginPlugin.py
+++ b/object_database/web/LoginPlugin.py
@@ -135,7 +135,8 @@ def authorized_groups_text(authorized_groups, default_text='All') -> str:
     """ Helper function that returns a string for display purposes. """
     res = default_text
     if authorized_groups:
-        return ', '.join(authorized_groups)
+        res = ', '.join(authorized_groups)
+    return res
 
 
 class LoginIpPlugin(LoginPluginInterface):

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -2072,7 +2072,8 @@ class _PlotUpdater(Cell):
 
             try:
                 jsonDataToDraw = self.calculatedDataJson()
-                self.postscript = """
+                self.postscript = (
+                    """
                     plotDiv = document.getElementById('plot__identity__');
                     data = __data__.map(mapPlotlyData)
 
@@ -2082,9 +2083,10 @@ class _PlotUpdater(Cell):
                         plotDiv.layout,
                         );
 
-                    """.replace("__identity__", self.chartId).replace("__data__",
-                        json.dumps(jsonDataToDraw)
-                        )
+                    """
+                    .replace("__identity__", self.chartId)
+                    .replace("__data__", json.dumps(jsonDataToDraw))
+                )
             except SubscribeAndRetry:
                 raise
             except Exception:

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -725,16 +725,21 @@ class Columns(Cell):
 
         self.elements = elements
         self.children = {"____c_%s__" % i: elements[i] for i in range(len(elements)) }
-        self.contents = """
+        self.contents = (
+            """
             <div class="container-fluid" __style__>
             <div class="row flex-nowrap">
                 __contents__
             </div>
             </div>
-        """.replace("__style__", self._divStyle()).replace("__contents__",
-            "\n".join(
-                """<div class="col-sm"> ____c_%s__ </div>""" % i
-                for i in range(len(elements)))
+            """
+            .replace("__style__", self._divStyle())
+            .replace(
+                "__contents__",
+                "\n".join(
+                    """<div class="col-sm"> ____c_%s__ </div>""" % i
+                    for i in range(len(elements)))
+            )
         )
 
     def __add__(self, other):
@@ -1582,7 +1587,8 @@ class Button(Clickable):
 
     def recalculate(self):
         self.children = {'____contents__': self.content}
-        self.contents = ("""
+        self.contents = (
+            """
             <button
                 class='btn btn-primary __size__'
                 onclick="__onclick__"
@@ -1922,7 +1928,8 @@ class Sheet(Cell):
 
                 rowData = self.rowFun(rowToRender)
 
-                self.triggerPostscript("""
+                self.triggerPostscript(
+                    """
                     var hot = handsOnTables["__identity__"]
 
                     hot.getSettings().data.cache[__row__] = __data__
@@ -1933,9 +1940,8 @@ class Sheet(Cell):
                 )
 
         if rows:
-            self.triggerPostscript("""
-                handsOnTables["__identity__"].render()
-                """
+            self.triggerPostscript(
+                """handsOnTables["__identity__"].render()"""
                 .replace("__identity__", self._identity)
             )
 

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -453,10 +453,10 @@ class Cell:
         t0 = time.time()
         while True:
             try:
-                with self.transaction() as t:
+                with self.transaction():
                     self.onMessage(*args)
                     return
-            except RevisionConflictException as e:
+            except RevisionConflictException:
                 tries += 1
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
                     self._logger.error("OnMessage timed out. This should really fail.")
@@ -859,8 +859,6 @@ class Tabs(Cell):
         self.whichSlot.set(index)
 
     def recalculate(self):
-        items = []
-
         self.children['____display__'] = Subscribed(lambda: self.headersAndChildren[self.whichSlot.get()][1])
 
         for i in range(len(self.headersAndChildren)):
@@ -2072,7 +2070,6 @@ class _PlotUpdater(Cell):
         with self.view() as v:
             # we only exist to run our postscript
             self.contents = """<div style="display:none">"""
-            hadChildren = len(self.children) > 0
             self.children = {}
             self.postscript = ""
             self.linePlot.error.set(None)

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -874,7 +874,7 @@ class Tabs(Cell):
                 "__items__",
                 "".join(
                     """ ____header___ix____ """.replace('__ix__', str(i))
-                        for i in range(len(self.headersAndChildren))
+                    for i in range(len(self.headersAndChildren))
                 )
             ).replace("__identity__", self._identity)
         )
@@ -933,7 +933,7 @@ class Dropdown(Cell):
                 """.replace(
                     "__onclick__",
                     "websocket.send(JSON.stringify({'event':'menu', 'ix': __ix__, 'target_cell': '__identity__'}))"
-                        if not isinstance(onDropdown, str) else
+                    if not isinstance(onDropdown, str) else
                     quoteForJs("window.location.href = '__url__'".replace("__url__", quoteForJs(onDropdown, "'")), '"')
                 ).replace("__ix__", str(i)).replace("__identity__", self.identity)
             )
@@ -1245,10 +1245,10 @@ class Grid(Cell):
                     ("<td>____rowlabel_%s__</td>" % row_ix if self.rowLabelFun is not None else "") +
                     "".join(
                         "<td>____child_%s_%s__</td>" % (row_ix, col_ix)
-                            for col_ix in range(len(self.cols))
+                        for col_ix in range(len(self.cols))
                     ) +
                     "</tr>"
-                        for row_ix in range(len(self.rows))
+                    for row_ix in range(len(self.rows))
                 )
             )
         )
@@ -1529,10 +1529,10 @@ class Table(Cell):
                     ("<td>%s</td>" % (row_ix+1)) +
                     "".join(
                         "<td>____child_%s_%s__</td>" % (row_ix, col_ix)
-                            for col_ix in range(len(self.cols))
+                        for col_ix in range(len(self.cols))
                     ) +
                     "</tr>"
-                        for row_ix in range(len(self.rows))
+                    for row_ix in range(len(self.rows))
                 )
             )
         )
@@ -1610,8 +1610,8 @@ class LoadContentsFromUrl(Cell):
 
         self.postscript = (
             "$('#loadtarget__identity__').load('__url__')"
-                .replace("__identity__", self._identity)
-                .replace("__url__", quoteForJs(self.targetUrl, "'"))
+            .replace("__identity__", self._identity)
+            .replace("__url__", quoteForJs(self.targetUrl, "'"))
         )
 
 

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -1237,7 +1237,7 @@ class Grid(Cell):
             .replace(
                 "__headers__",
                 "".join("<th>____header_%s__</th>" % (col_ix)
-                            for col_ix in range(len(self.cols))))
+                        for col_ix in range(len(self.cols))))
             .replace(
                 "__rows__",
                 "\n".join(
@@ -1521,7 +1521,7 @@ class Table(Cell):
             .replace(
                 "__headers__",
                 "".join('<th style="vertical-align:top">____header_%s__</th>' % (col_ix)
-                            for col_ix in range(len(self.cols))))
+                        for col_ix in range(len(self.cols))))
             .replace(
                 "__rows__",
                 "\n".join(
@@ -2026,11 +2026,10 @@ class _PlotUpdater(Cell):
         assert isinstance(series, (dict, list))
 
         if isinstance(series, dict):
-            return [self.processSeries(callableOrData, name) for name, callableOrData in
-                        series.items()]
+            return [self.processSeries(callableOrData, name)
+                    for name, callableOrData in series.items()]
         else:
-            return [self.processSeries(callableOrData, None) for callableOrData in
-                        series]
+            return [self.processSeries(callableOrData, None) for callableOrData in series]
 
     def callFun(self, fun):
         if not callable(fun):

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -449,6 +449,8 @@ class Cell:
 
     def onMessageWithTransaction(self, *args):
         """Call our inner 'onMessage' function with a transaction and a revision conflict retry loop."""
+        tries = 0
+        t0 = time.time()
         while True:
             try:
                 with self.transaction() as t:

--- a/object_database/web/cells_test.py
+++ b/object_database/web/cells_test.py
@@ -131,8 +131,8 @@ class CellsTests(unittest.TestCase):
 
     def test_cells_subscriptions(self):
         self.cells.root.setChild(
-            Subscribed(lambda:
-                Sequence([
+            Subscribed(
+                lambda: Sequence([
                     Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
                     for thing in Thing.lookupAll()
                 ])
@@ -243,8 +243,8 @@ class CellsTests(unittest.TestCase):
             cleanupFn()
 
     def test_cells_memory_leak1(self):
-        cell = Subscribed(lambda:
-            Sequence([
+        cell = Subscribed(
+            lambda: Sequence([
                 Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
                 for thing in Thing.lookupAll(k=0)
             ])

--- a/object_database/web/cells_test.py
+++ b/object_database/web/cells_test.py
@@ -259,13 +259,13 @@ class CellsTests(unittest.TestCase):
                     thing.delete()
                     thing = Thing(k=0, x=counter)
 
-                msg = cells.renderMessages()
+                cells.renderMessages()
 
         def initFn(db, cells):
             with db.transaction():
-                thing = Thing(k=0, x=0)
+                Thing(k=0, x=0)
 
-            msg = cells.renderMessages()
+            cells.renderMessages()
 
             workFn(db, cells, iterations=500)
 
@@ -303,11 +303,11 @@ class CellsTests(unittest.TestCase):
                     for anything in all_things:
                         anything.x = anything.x + 1
 
-                msg = cells.renderMessages()
+                cells.renderMessages()
 
         def initFn(db, cells):
             with db.transaction():
-                thing = Thing(x=1, k=0)
+                Thing(x=1, k=0)
 
             cells.renderMessages()
 

--- a/test.py
+++ b/test.py
@@ -172,14 +172,14 @@ def applyFilterActions(filterActions, tests):
 
     for action, pattern in filterActions:
         if action == "add":
-            filtered += [x for x in tests if
-                                    regexMatchesSubstring(pattern, x.id())]
+            filtered += [x for x in tests
+                         if regexMatchesSubstring(pattern, x.id())]
         elif action == "filter":
-            filtered = [x for x in filtered if
-                                    regexMatchesSubstring(pattern, x.id())]
+            filtered = [x for x in filtered
+                        if regexMatchesSubstring(pattern, x.id())]
         elif action == "exclude":
-            filtered = [x for x in filtered if
-                                    not regexMatchesSubstring(pattern, x.id())]
+            filtered = [x for x in filtered
+                        if not regexMatchesSubstring(pattern, x.id())]
         else:
             assert False
 

--- a/test.py
+++ b/test.py
@@ -73,10 +73,10 @@ def loadTestModules(testFiles, rootDir):
 def fileNameToModuleName(fileName, rootDir):
     tr = (
         fileName
-            .replace('.py', '')
-            .replace(rootDir, '', 1)  # only replace the first occurrence
-            .replace(os.sep, '.')
-            )
+        .replace('.py', '')
+        .replace(rootDir, '', 1)  # only replace the first occurrence
+        .replace(os.sep, '.')
+    )
     if tr.startswith('.'):
         return tr[1:]
     return tr

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ ignore =
     E226,  # missing whitespace around arithmetic operator
     E227,  # missing whitespace around bitwise or shift operator
     E228,  # missing whitespace around modulo operator
+    E731,  # do not assign a lambda expression, use a def
 exclude = 
     .git,
     .venv,
@@ -22,6 +23,7 @@ ignore =
     E226,  # missing whitespace around arithmetic operator
     E227,  # missing whitespace around bitwise or shift operator
     E228,  # missing whitespace around modulo operator
+    E731,  # do not assign a lambda expression, use a def
 exclude = 
     .git,
     .venv,

--- a/typed_python/Codebase.py
+++ b/typed_python/Codebase.py
@@ -67,8 +67,6 @@ class Codebase:
                 import object_database
                 import typed_python
 
-                allModules = []
-
                 context1 = SerializationContext.FromModules(
                     Codebase._walkModuleDiskRepresentation(typed_python)[2].values()
                 )

--- a/typed_python/class_types_test.py
+++ b/typed_python/class_types_test.py
@@ -192,8 +192,6 @@ class NativeClassTypesTests(unittest.TestCase):
         self.assertEqual(e.iTup.x.x, 10)
 
     def test_class_stringification(self):
-        i = Interior()
-
         self.assertEqual(Interior.__qualname__, "Interior")
         self.assertEqual(str(Interior()), "Interior(x=0, y=0)")
 

--- a/typed_python/forward_types_test.py
+++ b/typed_python/forward_types_test.py
@@ -40,7 +40,7 @@ class NativeForwardTypesTests(unittest.TestCase):
         self.assertEqual(list(l.unpack()), list(reversed(range(100))))
 
     def test_instantiating_invalid_forward(self):
-        X = Alternative("X", A={'x': lambda: this_does_not_Exist })
+        X = Alternative("X", A={'x': lambda: this_does_not_Exist })  # noqa
 
         with self.assertRaises(TypeError):
             X.A()

--- a/typed_python/forward_types_test.py
+++ b/typed_python/forward_types_test.py
@@ -83,7 +83,7 @@ class NativeForwardTypesTests(unittest.TestCase):
         Y = OneOf(None, lambda: X)
         X = TupleOf(Y)
 
-        xStr = str(X)
+        str(X)
 
         anX = X( (None,) )
 
@@ -96,7 +96,7 @@ class NativeForwardTypesTests(unittest.TestCase):
     def test_deep_forwards_work(self):
         X = TupleOf(TupleOf(TupleOf(TupleOf(OneOf(None, lambda: X)))))
 
-        xStr = str(X)
+        str(X)
 
         anX = X( ((((None,),),),) )
 

--- a/typed_python/python_ast.py
+++ b/typed_python/python_ast.py
@@ -721,7 +721,7 @@ def convertPyAstToAlgebraic(tree, fname, keepLineInformation=True):
 
             try:
                 return converter(**args)
-            except Exception as e:
+            except Exception:
                 import traceback
                 raise UserWarning(
                     "Failed to construct %s from %s with arguments\n%s\n\n%s"
@@ -753,7 +753,7 @@ def convertFunctionToAlgebraicPyAst(f, keepLineInformation=True):
         _, fname = ast_util.getSourceFilenameAndText(f)
 
         pyast = ast_util.functionDefOrLambdaAtLineNumber(pyast, lineno)
-    except Exception as e:
+    except Exception:
         raise Exception("Failed to get source for function %s" % (f.__qualname__))
 
     try:

--- a/typed_python/python_ast.py
+++ b/typed_python/python_ast.py
@@ -42,14 +42,16 @@ Keyword = lambda: Keyword
 Alias = lambda: Alias
 WithItem = lambda: WithItem
 
-Module = Alternative("Module",
+Module = Alternative(
+    "Module",
     Module={"body": TupleOf(Statement)},
     Expression={'body': Expr},
     Interactive={'body': TupleOf(Statement)},
     Suite={"body": TupleOf(Statement)}
 )
 
-Statement = Alternative("Statement",
+Statement = Alternative(
+    "Statement",
     FunctionDef={
         "name": str,
         "args": Arguments,
@@ -205,7 +207,8 @@ Statement = Alternative("Statement",
     }
 )
 
-Expr = Alternative("Expr",
+Expr = Alternative(
+    "Expr",
     BoolOp={
         "op": BooleanOp,
         "values": TupleOf(Expr),
@@ -365,7 +368,8 @@ Expr = Alternative("Expr",
     }
 )
 
-NumericConstant = Alternative("NumericConstant",
+NumericConstant = Alternative(
+    "NumericConstant",
     Int={"value": int},
     Long={"value": str},
     Boolean={"value": bool},
@@ -374,7 +378,8 @@ NumericConstant = Alternative("NumericConstant",
     Unknown={}
 )
 
-ExprContext = Alternative("ExprContext",
+ExprContext = Alternative(
+    "ExprContext",
     Load={},
     Store={},
     Del={},
@@ -383,7 +388,8 @@ ExprContext = Alternative("ExprContext",
     Param={}
 )
 
-Slice = Alternative("Slice",
+Slice = Alternative(
+    "Slice",
     Ellipsis={},
     Slice={
         "lower": OneOf(Expr, None),
@@ -394,12 +400,14 @@ Slice = Alternative("Slice",
     Index={"value": Expr}
 )
 
-BooleanOp = Alternative("BooleanOp",
+BooleanOp = Alternative(
+    "BooleanOp",
     And={},
     Or={}
 )
 
-BinaryOp = Alternative("BinaryOp",
+BinaryOp = Alternative(
+    "BinaryOp",
     Add={},
     Sub={},
     Mult={},
@@ -414,14 +422,16 @@ BinaryOp = Alternative("BinaryOp",
     FloorDiv={}
 )
 
-UnaryOp = Alternative("UnaryOp",
+UnaryOp = Alternative(
+    "UnaryOp",
     Invert={},
     Not={},
     UAdd={},
     USub={}
 )
 
-ComparisonOp = Alternative("ComparisonOp",
+ComparisonOp = Alternative(
+    "ComparisonOp",
     Eq={},
     NotEq={},
     Lt={},
@@ -434,7 +444,8 @@ ComparisonOp = Alternative("ComparisonOp",
     NotIn={}
 )
 
-Comprehension = Alternative("Comprehension",
+Comprehension = Alternative(
+    "Comprehension",
     Item={
         "target": Expr,
         "iter": Expr,
@@ -443,7 +454,8 @@ Comprehension = Alternative("Comprehension",
     }
 )
 
-ExceptionHandler = Alternative("ExceptionHandler",
+ExceptionHandler = Alternative(
+    "ExceptionHandler",
     Item={
         "type": OneOf(Expr, None),
         "name": OneOf(str, None),
@@ -454,7 +466,8 @@ ExceptionHandler = Alternative("ExceptionHandler",
     }
 )
 
-Arguments = Alternative("Arguments",
+Arguments = Alternative(
+    "Arguments",
     Item={
         "args": TupleOf(Arg),
         "vararg": OneOf(Arg, None),
@@ -465,30 +478,35 @@ Arguments = Alternative("Arguments",
     }
 )
 
-Arg = Alternative("Arg",
+Arg = Alternative(
+    "Arg",
     Item={
         'arg': str,
         'annotation': OneOf(Expr, None),
         'line_number': int,
         'col_offset': int,
         'filename': str
-    })
+    }
+)
 
-Keyword = Alternative("Keyword",
+Keyword = Alternative(
+    "Keyword",
     Item={
         "arg": OneOf(None, str),
         "value": Expr
     }
 )
 
-Alias = Alternative("Alias",
+Alias = Alternative(
+    "Alias",
     Item={
         "name": str,
         "asname": OneOf(str, None)
     }
 )
 
-WithItem = Alternative("WithItem",
+WithItem = Alternative(
+    "WithItem",
     Item={
         "context_expr": Expr,
         "optional_vars": OneOf(Expr, None),

--- a/typed_python/python_ast_test.py
+++ b/typed_python/python_ast_test.py
@@ -53,7 +53,7 @@ class TestPythonAst(unittest.TestCase):
         def f(x):
             try:
                 A()
-            except Exception as e:
+            except Exception:
                 pass
             else:
                 print("hihi")
@@ -112,7 +112,7 @@ class TestPythonAst(unittest.TestCase):
 
     def test_reverse_parse_eval_withblock(self):
         def f(x, filename):
-            with open(filename, 'r') as f:
+            with open(filename, 'r'):
                 pass
             return x+x
 

--- a/typed_python/type_function_test.py
+++ b/typed_python/type_function_test.py
@@ -35,8 +35,8 @@ class TypeFunctionTest(unittest.TestCase):
         l_i = List(int).Empty()
         l_f = List(float).Empty()
 
-        l_i_2 = List(int).Node(head=10, tail=l_i)
-        l_f_2 = List(float).Node(head=10.5, tail=l_f)
+        List(int).Node(head=10, tail=l_i)
+        List(float).Node(head=10.5, tail=l_f)
 
         with self.assertRaises(TypeError):
             List(int).Node(head=10, tail=l_f)

--- a/typed_python/type_function_test.py
+++ b/typed_python/type_function_test.py
@@ -20,7 +20,8 @@ class TypeFunctionTest(unittest.TestCase):
     def test_basic(self):
         @TypeFunction
         def List(T):
-            return Alternative("List",
+            return Alternative(
+                "List",
                 Node={"head": T, "tail": List(T)},
                 Empty={}
             )
@@ -77,7 +78,8 @@ class TypeFunctionTest(unittest.TestCase):
     def test_can_serialize_type_functions(self):
         @TypeFunction
         def List(T):
-            return Alternative("List",
+            return Alternative(
+                "List",
                 Node={"head": T, "tail": List(T)},
                 Empty={}
             )

--- a/typed_python/types_metadata_test.py
+++ b/typed_python/types_metadata_test.py
@@ -39,7 +39,8 @@ class TypesMetadataTest(unittest.TestCase):
         self.assertEqual(ConstDict(str, int).ValueType, Int64)
 
     def test_alternatives(self):
-        X = Alternative("X",
+        X = Alternative(
+            "X",
             Left={'x': int, 'y': str},
             Right={'x': lambda: X, 'val': int}
         )

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -68,7 +68,7 @@ class K(object):
         return K, (self.value,)
 
 
-import __main__
+import __main__  # noqa
 __main__.C = C
 C.__module__ = "__main__"
 __main__.D = D

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -832,11 +832,11 @@ class TypesSerializationTest(unittest.TestCase):
     # Didn't even bother
     @unittest.skip
     def test_serialize_dynamic_class(self):
+        import copyreg
         a = create_dynamic_class("my_dynamic_class", (object,))
         copyreg.pickle(pickling_metaclass, pickling_metaclass.__reduce__)
 
-        s = self.dumps(a, proto)
-        b = self.loads(s)
+        b = ping_pong(a)
         self.assertEqual(a, b)
         self.assertIs(type(a), type(b))
 
@@ -851,13 +851,11 @@ class TypesSerializationTest(unittest.TestCase):
         self.assert_is_copy(t, u)
         if hasattr(os, "stat"):
             t = os.stat(os.curdir)
-            s = self.dumps(t, proto)
-            u = self.loads(s)
+            u = ping_pong(t)
             self.assert_is_copy(t, u)
         if hasattr(os, "statvfs"):
             t = os.statvfs(os.curdir)
-            s = self.dumps(t, proto)
-            u = self.loads(s)
+            u = ping_pong(t)
             self.assert_is_copy(t, u)
 
     # FAILS

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -134,7 +134,7 @@ def create_data():
     x.extend([1, -1,
               uint1max, -uint1max, -uint1max-1,
               uint2max, -uint2max, -uint2max-1,
-               int4max, -int4max, -int4max-1])
+              int4max, -int4max, -int4max-1])
     y = ('abc', 'abc', c, c)
     x.append(y)
     x.append(y)

--- a/typed_python/types_serialization_test.py
+++ b/typed_python/types_serialization_test.py
@@ -447,8 +447,6 @@ class TypesSerializationTest(unittest.TestCase):
         self.assertTrue(numpy.all(ping_pong({'a': x, 'b': x})['a'] == x))
 
     def test_serialize_and_threads(self):
-        x = numpy.ones(10000)
-
         class A:
             def __init__(self, x):
                 self.x = x
@@ -490,10 +488,10 @@ class TypesSerializationTest(unittest.TestCase):
 
     def test_bad_serialization_context(self):
         with self.assertRaises(AssertionError):
-            ts = SerializationContext({'': int})
+            SerializationContext({'': int})
 
         with self.assertRaises(AssertionError):
-            ts = SerializationContext({b'': int})
+            SerializationContext({b'': int})
 
     def test_serialization_context_queries(self):
         sc = SerializationContext({
@@ -702,37 +700,37 @@ class TypesSerializationTest(unittest.TestCase):
 
     def test_serialize_base_type_subclass(self):
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyInt())
+            sc.serialize(MyInt())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyFloat())
+            sc.serialize(MyFloat())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyComplex())
+            sc.serialize(MyComplex())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyStr())
+            sc.serialize(MyStr())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyUnicode())
+            sc.serialize(MyUnicode())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyBytes())
+            sc.serialize(MyBytes())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyTuple())
+            sc.serialize(MyTuple())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyList())
+            sc.serialize(MyList())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyDict())
+            sc.serialize(MyDict())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MySet())
+            sc.serialize(MySet())
 
         with self.assertRaises(TypeError):
-            ser = sc.serialize(MyFrozenSet())
+            sc.serialize(MyFrozenSet())
 
     # THIS FAILS
     @unittest.skip

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -738,10 +738,8 @@ class NativeTypesTests(unittest.TestCase):
         self.assertLess(t({}), t({'a': 'b'}))
 
     def test_const_dict_lookup(self):
-        for type_to_use, vals in [
-                    (int, list(range(20))),
-                    (bytes, [b'1', b'2', b'3', b'4', b'5'])
-        ]:
+        for type_to_use, vals in [(int, list(range(20))),
+                                  (bytes, [b'1', b'2', b'3', b'4', b'5'])]:
             t = ConstDict(type_to_use, type_to_use)
 
             for _ in range(10):

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -638,7 +638,8 @@ class NativeTypesTests(unittest.TestCase):
             for f in funcs:
                 for t1 in ts:
                     for t2 in ts:
-                        self.assertTrue(f(t1, t2) is f(t((t1,)), t((t2,))),
+                        self.assertTrue(
+                            f(t1, t2) is f(t((t1,)), t((t2,))),
                             (f, t1, t2, f(t1, t2), f(t((t1,)), t((t2,))))
                         )
 
@@ -925,7 +926,8 @@ class NativeTypesTests(unittest.TestCase):
         self.assertEqual(empty.B(), empty.B())
         self.assertNotEqual(empty.A(), empty.B())
 
-        a = Alternative("X",
+        a = Alternative(
+            "X",
             A={'a': int},
             B={'b': int},
             C={'c': str},

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -1131,8 +1131,6 @@ class NativeTypesTests(unittest.TestCase):
             print(time.time() - t0, " for ", len(ints))
 
     def test_serialization_roundtrip(self):
-        badlen = None
-
         for _ in range(100):
             producer = RandomValueProducer()
             producer.addEvenly(30, 3)


### PR DESCRIPTION
## Overview
After these changes, flake8 complains about the following:
```
570   E501 line too long (110 > 99 characters)
3     E721 do not compare types, use 'isinstance()'
39    E741 ambiguous variable name 'l'
406   F401 'nativepython.runtime.Entrypoint' imported but unused
30    F403 'from typed_python import *' used; unable to detect undefined names
421   F405 'Alternative' may be undefined, or defined from star imports: typed_python
1     F632 use ==/!= to compare str, bytes, and int literals
29    F811 redefinition of unused '__init__' from line 63
8     F821 undefined name 'out'
2     F841 local variable 'native_output_type' is assigned to but never used
16    W503 line break before binary operator
65    W504 line break after binary operator
1590
```

## TODO [Done]
 Fixed most "F841: local variable 'xyz' is assigned to but never used" errors, but  a couple of instances remain:
```
./nativepython/python_to_native_converter.py:79:13: F841 local variable 'native_output_type' is assigned to but never used
            native_output_type = output_type.getNativeLayoutType()
            ^
./nativepython/python_to_native_converter.py:161:13: F841 local variable 'body' is assigned to but never used
            body = [python_ast.Statement.Return(
            ^
```