### PR TITLE
[WIP] Multi-Stage TravisCI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ env:
 #   - pip install pipenv
 #   - pipenv install --dev --deploy
 
-cache: pip
+cache:
+  directories:
+    - $HOME/.cache/pip
+
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ install:
   - pip install pipenv
   - pipenv install --dev --deploy
 
-script:
-  - make testcert.cert
-  - flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
-  - ./test.py -s
-  - pipenv check
+
+jobs:
+  include:
+    - stage: "test"
+      script: flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
+    - script: pipenv check
+    - script: ./test.py -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
   include:
     - stage: "install"
       # script: pip install pipenv; pipenv install --dev --deploy
-      script: pip install pipenv; pipenv lock --dev --requirements > requirements.txt; pip install -r requirements.txt; flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
+      script: pip install pipenv; pipenv lock --dev --requirements > requirements.txt; pip install -r requirements.txt; flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403; which flake8
     - stage: "test"
       script: flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
     - script: pipenv check

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ cache: pip
 jobs:
   include:
     - stage: "install"
-      script: pip install pipenv; pipenv install --dev --deploy
+      # script: pip install pipenv; pipenv install --dev --deploy
+      script: pip install pipenv; pipenv lock --dev --requirements > requirements.txt; pip install -r requirements.txt
     - stage: "test"
       script: flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
     - script: pipenv check

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,21 @@ env:
   global:
     - TRAVIS_CI=true
 
-install:
-  - pip install pipenv
-  - pipenv install --dev --deploy
+# install:
+#   - pip install pipenv
+#   - pipenv install --dev --deploy
 
 
 jobs:
   include:
+    - stage: "install"
+      script: pip install pipenv; pipenv install --dev --deploy
     - stage: "test"
       script: flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
     - script: pipenv check
     - script: ./test.py -s
+
+
+stages:
+  - install
+  - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
   include:
     - stage: "install"
       # script: pip install pipenv; pipenv install --dev --deploy
-      script: pip install pipenv; pipenv lock --dev --requirements > requirements.txt; pip install -r requirements.txt
+      script: pip install pipenv; pipenv lock --dev --requirements > requirements.txt; pip install -r requirements.txt; flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
     - stage: "test"
       script: flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
     - script: pipenv check

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
 #   - pip install pipenv
 #   - pipenv install --dev --deploy
 
+cache: pip
 
 jobs:
   include:

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ test: testcert.cert testcert.key install
 .PHONY: lint
 lint: $(VIRTUAL_ENV)
 	. $(VIRTUAL_ENV)/bin/activate; \
-	flake8 --statistics
+	flake8 --show-source --select=E999,E722,W291,W292,W293,W391,F403
 
 .PHONY: lib
 lib: typed_python/_types.cpython-36m-x86_64-linux-gnu.so

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ ignore =
     E227,  # missing whitespace around bitwise or shift operator
     E228,  # missing whitespace around modulo operator
     E731,  # do not assign a lambda expression, use a def
-exclude = 
+exclude =
     .git,
     .venv,
     build,
@@ -24,7 +24,7 @@ ignore =
     E227,  # missing whitespace around bitwise or shift operator
     E228,  # missing whitespace around modulo operator
     E731,  # do not assign a lambda expression, use a def
-exclude = 
+exclude =
     .git,
     .venv,
     build,


### PR DESCRIPTION
# Purpose
Separate the different things we test for on TravisCI into different "stages". This is useful for keeping the output of tests a bit neater, and for parallelizing testing (which at our current free tier is not an option).

# Approach
Break our test script into the following stages
1st stage: Lint
2nd stage: pipenv check
3rd stage: unit testing

# Testing
Checked that TravisCI did each of the tests in a distinct stage. But noticed that each stage re-installed the dependencies, which is slowing things down unnecessarily. I tried to cache the installation step, but after about one hour of trying unsuccessfully, I am benching this. I have learned that each stage will boot its own virtual machine, so it doesn't make sense to do that for linting and pipenv check which each take a couple of seconds because the overhead of bringing up a new virtual machine, let alone the issue that I haven't yet figured out how to cache the installation step which take an additional minute and a half, exceed by a lot the length of each of those stages.

I am going to close this PR (but keep it) to have a record of this work, should we want to revisit it in the future

