### PR TITLE
Support Callable ConcreteAlternatives

### DIFF
--- a/typed_python/PyAlternativeInstance.cpp
+++ b/typed_python/PyAlternativeInstance.cpp
@@ -328,7 +328,7 @@ PyObject* PyConcreteAlternativeInstance::tp_call_concrete(PyObject* args, PyObje
             "'%s' object is not callable because '__call__' was not defined",
             type()->name().c_str()
             );
-        return nullptr;
+        throw PythonExceptionSet();
     } else {
         Function* f = it->second;
 

--- a/typed_python/PyAlternativeInstance.cpp
+++ b/typed_python/PyAlternativeInstance.cpp
@@ -318,3 +318,29 @@ int PyConcreteAlternativeInstance::tp_setattr_concrete(PyObject* attrName, PyObj
     return -1;
 }
 
+
+PyObject* PyConcreteAlternativeInstance::tp_call_concrete(PyObject* args, PyObject* kwargs) {
+    auto it = type()->getAlternative()->getMethods().find("__call__");
+
+    if (it == type()->getAlternative()->getMethods().end()) {
+        PyErr_Format(
+            PyExc_TypeError,
+            "'%s' object is not callable because '__call__' was not defined",
+            type()->name().c_str()
+            );
+        return nullptr;
+    } else {
+        Function* f = it->second;
+
+        for (const auto& overload: f->getOverloads()) {
+            std::pair<bool, PyObject*> res = PyFunctionInstance::tryToCallOverload(
+                overload, (PyObject*)this, args, kwargs
+                );
+
+            if (res.first) {
+                return res.second;
+            }
+        }
+    }
+}
+

--- a/typed_python/PyAlternativeInstance.hpp
+++ b/typed_python/PyAlternativeInstance.hpp
@@ -41,6 +41,8 @@ public:
 
     int tp_setattr_concrete(PyObject* attrName, PyObject* attrVal);
 
+    PyObject* tp_call_concrete(PyObject* args, PyObject* kwargs);
+
     static bool pyValCouldBeOfTypeConcrete(modeled_type* type, PyObject* pyRepresentation) {
         return true;
     }

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -779,7 +779,7 @@ PyTypeObject* PyInstance::typeObjInternal(Type* inType) {
                          ?
                 PyInstance::tp_iter
             :   0,                                      // getiterfunc tp_iter;
-            .tp_iternext = PyInstance::tp_iternext,// iternextfunc
+            .tp_iternext = PyInstance::tp_iternext,     // iternextfunc
             .tp_methods = typeMethods(inType),          // struct PyMethodDef*
             .tp_members = 0,                            // struct PyMemberDef*
             .tp_getset = 0,                             // struct PyGetSetDef*
@@ -790,7 +790,7 @@ PyTypeObject* PyInstance::typeObjInternal(Type* inType) {
             .tp_dictoffset = 0,                         // Py_ssize_t
             .tp_init = 0,                               // initproc
             .tp_alloc = 0,                              // allocfunc
-            .tp_new = PyInstance::tp_new,  // newfunc
+            .tp_new = PyInstance::tp_new,                // newfunc
             .tp_free = 0,                               // freefunc /* Low-level free-memory routine */
             .tp_is_gc = 0,                              // inquiry  /* For PyObject_IS_GC */
             .tp_bases = 0,                              // PyObject*
@@ -798,7 +798,7 @@ PyTypeObject* PyInstance::typeObjInternal(Type* inType) {
             .tp_cache = 0,                              // PyObject*
             .tp_subclasses = 0,                         // PyObject*
             .tp_weaklist = 0,                           // PyObject*
-            .tp_del = 0,                               // destructor
+            .tp_del = 0,                                // destructor
             .tp_version_tag = 0,                        // unsigned int
             .tp_finalize = 0,                           // destructor
             }, inType

--- a/typed_python/PyInstance.cpp
+++ b/typed_python/PyInstance.cpp
@@ -867,7 +867,7 @@ PyObject* PyInstance::tp_call(PyObject* o, PyObject* args, PyObject* kwargs) {
 
 PyObject* PyInstance::tp_call_concrete(PyObject* args, PyObject* kwargs) {
     PyErr_Format(PyExc_TypeError, "'%s' object is not callable", type()->name().c_str());
-    return 0;
+    return nullptr;
 }
 
 PyObject* PyInstance::tp_getattr_concrete(PyObject* pyAttrName, const char* attrName) {
@@ -878,7 +878,7 @@ PyObject* PyInstance::tp_getattr_concrete(PyObject* pyAttrName, const char* attr
 PyObject* PyInstance::tp_getattro(PyObject *o, PyObject* attrName) {
     if (!PyUnicode_Check(attrName)) {
         PyErr_SetString(PyExc_AttributeError, "attribute is not a string");
-        return NULL;
+        return nullptr;
     }
 
     char *attr_name = PyUnicode_AsUTF8(attrName);

--- a/typed_python/internals.py
+++ b/typed_python/internals.py
@@ -89,6 +89,7 @@ def makeFunction(name, f, firstArgType=None):
     spec = inspect.getfullargspec(f)
 
     def getAnn(argname):
+        """ Return the annotated type for the given argument or None. """
         if argname not in spec.annotations:
             return None
         else:
@@ -98,15 +99,21 @@ def makeFunction(name, f, firstArgType=None):
             else:
                 return ann
 
-    arg_types = []
-    for i, argname in enumerate(spec.args):
+    def getDefault(idx: int):
+        """ Return the default value for a positional argument given its index. """
         if spec.defaults is not None:
-            if i >= len(spec.args) - len(spec.defaults):
-                default = (spec.defaults[i-(len(spec.args) - len(spec.defaults))],)
+            if idx >= len(spec.args) - len(spec.defaults):
+                default = (spec.defaults[idx -(len(spec.args) - len(spec.defaults))],)
             else:
                 default = None
         else:
             default = None
+
+        return default
+
+    arg_types = []
+    for i, argname in enumerate(spec.args):
+        default = getDefault(i)
 
         ann = getAnn(argname)
         if ann is None and i == 0 and firstArgType is not None:

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -252,6 +252,15 @@ class NativeTypesTests(unittest.TestCase):
         two = alt.Two()
         self.assertEqual(two(), 42)
 
+        alt = Alternative("alts", One = {}, Two = {}, myCall = myCall)
+        with self.assertRaises(TypeError):
+            one = alt.One()
+            one()
+
+        with self.assertRaises(TypeError):
+            two = alt.Two()
+            two()
+
     def test_object_bytecounts(self):
         self.assertEqual(_types.bytecount(NoneType), 0)
         self.assertEqual(_types.bytecount(Int8), 1)

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -240,6 +240,18 @@ class NativeTypesTests(unittest.TestCase):
         self.assertFalse(ibc(A1.X, A2.Y))
         self.assertFalse(ibc(A1.Y, A2.X))
 
+    def test_callable_alternatives(self):
+        def myCall(self, *args, **kwargs):
+            return 42
+
+        alt = Alternative("alts", One = {}, Two = {}, __call__ = myCall)
+
+        one = alt.One()
+        self.assertEqual(one(), 42)
+
+        two = alt.Two()
+        self.assertEqual(two(), 42)
+
     def test_object_bytecounts(self):
         self.assertEqual(_types.bytecount(NoneType), 0)
         self.assertEqual(_types.bytecount(Int8), 1)


### PR DESCRIPTION
# Purpose
`Alternatives` allow us to define methods, so we should be allowed to define a `__call__` method and therefore make the alternative callable. This PR adds support for this feature

# Approach
The `__call__` function is treated as a regular function, and at `tp_call` dispatch-time, we check whether the concrete alternative has a `__call__` method, and if so, we try to call it.