### PR TITLE
Compile str.lower()

### DIFF
--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -146,3 +146,45 @@ class TestStringCompilation(unittest.TestCase):
         someupper_strings = ["Abc","aBc","abC", "ABC","\u00CA\u00D1\u011A\u1E66\u1EEA","XyZ\U0001D471"]
         for s in someupper_strings:
             self.assertEqual(s.lower(), c_lower(s))
+
+
+    def test_string_find(self):
+
+        @Compiled
+        def c_find(s: str, sub: str, start: int, end: int):
+            return s.find(sub, start, end)
+
+        @Compiled
+        def c_find_3(s: str, sub: str, start: int):
+            return s.find(sub, start)
+
+        @Compiled
+        def c_find_2(s: str, sub: str):
+            return s.find(sub)
+
+        def test_find(teststring):
+            substrings = ["", "x", "xyz", teststring[0:-2] + teststring[-1] ]
+            for start in range(0,len(teststring)):
+                for end in range(start+1,len(teststring)+1):
+                    substrings.append(teststring[start:end])
+            for sub in substrings:
+                for start in range(-len(teststring)-1, len(teststring)+1):
+                    for end in range(-len(teststring)-1, len(teststring)+1):
+                        i = teststring.find(sub, start, end)
+                        c_i = c_find(teststring, sub, start, end)
+                        self.assertEqual(i, c_i)
+            for sub in substrings:
+                for start in range(-len(teststring)-1, len(teststring)+1):
+                    i = teststring.find(sub, start)
+                    c_i = c_find_3(teststring, sub, start)
+                    self.assertEqual(i, c_i)
+            for sub in substrings:
+                i = teststring.find(sub)
+                c_i = c_find_2(teststring, sub)
+                self.assertEqual(i, c_i)
+
+        test_find("abcdef")
+        test_find("\u00CA\u00D1\u011A\u1E66\u1EEA")
+        test_find("\u00DD\U00012EEE\U0001D471\u00AA\U00011234")
+
+

--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -135,3 +135,14 @@ class TestStringCompilation(unittest.TestCase):
         for s in someStrings:
             for i in range(-20, 20):
                 self.assertEqual(callOrExcept(getitem, s, i), callOrExcept(lambda s, i: s[i], s, i), (s, i))
+
+
+    def test_string_lower(self):
+
+        @Compiled
+        def c_lower(s: str):
+            return s.lower()
+
+        someupper_strings = ["Abc","aBc","abC", "ABC","\u00CA\u00D1\u011A\u1E66\u1EEA","XyZ\U0001D471"]
+        for s in someupper_strings:
+            self.assertEqual(s.lower(), c_lower(s))

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -137,6 +137,26 @@ string_lower = externalCallTarget(
     Void.pointer()
 )
 
+string_find = externalCallTarget(
+    "nativepython_runtime_string_find",
+    Int64,
+    Void.pointer(), Void.pointer(), Int64, Int64
+)
+
+string_find_2 = externalCallTarget(
+    "nativepython_runtime_string_find_2",
+    Int64,
+    Void.pointer(), Void.pointer()
+)
+
+string_find_3 = externalCallTarget(
+    "nativepython_runtime_string_find_3",
+    Int64,
+    Void.pointer(), Void.pointer(), Int64
+)
+
+
+
 bytes_concat = externalCallTarget(
     "nativepython_runtime_bytes_concat",
     Void.pointer(),

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -131,6 +131,12 @@ string_from_utf8_and_len = externalCallTarget(
     UInt8Ptr, Int64
 )
 
+string_lower = externalCallTarget(
+    "nativepython_runtime_string_lower",
+    Void.pointer(),
+    Void.pointer()
+)
+
 bytes_concat = externalCallTarget(
     "nativepython_runtime_bytes_concat",
     Void.pointer(),

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -13,6 +13,9 @@
 #   limitations under the License.
 
 from nativepython.type_wrappers.refcounted_wrapper import RefcountedWrapper
+from typed_python import Int64
+from nativepython.type_wrappers.arithmetic_wrapper import Int64Wrapper
+
 import nativepython.type_wrappers.runtime_functions as runtime_functions
 from nativepython.type_wrappers.bound_compiled_method_wrapper import BoundCompiledMethodWrapper
 
@@ -140,7 +143,7 @@ class StringWrapper(RefcountedWrapper):
         )
 
     def convert_attribute(self, context, instance, attr):
-        if attr in ("lower",):
+        if attr in ("lower", "find"):
             return instance.changeType(BoundCompiledMethodWrapper(self, attr))
 
         return super().convert_attribute(context, instance, attr)
@@ -160,5 +163,41 @@ class StringWrapper(RefcountedWrapper):
                     ).cast(self.layoutType)
                 )
             )
+        elif methodname == "find":
+            if len(args) == 1:
+                return context.push(
+                    Int64,
+                    lambda iRef: iRef.expr.store(
+                        runtime_functions.string_find_2.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            args[0].nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                )
+            elif len(args) == 2:
+                return context.push(
+                    Int64,
+                    lambda iRef: iRef.expr.store(
+                        runtime_functions.string_find_3.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            args[0].nonref_expr.cast(VoidPtr),
+                            args[1].nonref_expr
+                        )
+                    )
+                )
+            elif len(args) == 3:
+                return context.push(
+                    Int64,
+                    lambda iRef: iRef.expr.store(
+                        runtime_functions.string_find.call(
+                        instance.nonref_expr.cast(VoidPtr),
+                        args[0].nonref_expr.cast(VoidPtr),
+                        args[1].nonref_expr,
+                        args[2].nonref_expr
+                    )
+                )
+            )
+            else:
+                return
 
         return super().convert_method_call(context, instance, methodname, args, kwargs)

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -82,6 +82,37 @@ String::layout* String::concatenate(layout* lhs, layout* rhs) {
     return new_layout;
 }
 
+String::layout* String::lower(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->pointcount * l->bytes_per_codepoint;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytes_per_codepoint = l->bytes_per_codepoint;
+    new_layout->pointcount = l->pointcount;
+
+    if (l->bytes_per_codepoint == 1) {
+        for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->pointcount; src < end; ) {
+            *dest++ = (uint8_t)tolower(*src++);
+        }
+    }
+    else if (l->bytes_per_codepoint == 2) {
+        for (uint16_t *src = (uint16_t *)l->data, *dest = (uint16_t *)new_layout->data, *end = src + l->pointcount; src < end; ) {
+            *dest++ = (uint16_t)towlower(*src++);
+        }
+    }
+    else if (l->bytes_per_codepoint == 4) {
+        for (uint32_t *src = (uint32_t *)l->data, *dest = (uint32_t *)new_layout->data, *end = src + l->pointcount; src < end; ) {
+            *dest++ = (uint32_t)towlower(*src++);
+        }
+    }
+
+    return new_layout;
+}
+
 String::layout* String::getitem(layout* lhs, int64_t offset) {
     if (!lhs) {
         return lhs;
@@ -136,7 +167,7 @@ int64_t String::bytesPerCodepointRequiredForUtf8(const uint8_t* utf8Str, int64_t
         if (utf8Str[0] >> 4 == 0b1110) {
             length -= 1;
             utf8Str += 3;
-            bytes_per_codepoint = std::max<int64_t>(4, bytes_per_codepoint);
+            bytes_per_codepoint = std::max<int64_t>(2, bytes_per_codepoint);
         }
 
         if (utf8Str[0] >> 3 == 0b11110) {

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -37,6 +37,11 @@ public:
     //return an increffed lowercase conversion layout of l
     static layout* lower(layout *l);
 
+    //return the lowest index in the string where substring sub is found within l[start, end]
+    static int64_t find(layout* l, layout* sub, int64_t start, int64_t end);
+    static int64_t find_2(layout* l, layout* sub);
+    static int64_t find_3(layout* l, layout* sub, int64_t start);
+
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.
     static layout* getitem(layout* lhs, int64_t offset);

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -34,6 +34,9 @@ public:
     //return an increffed concatenated layout of lhs and rhs
     static layout* concatenate(layout* lhs, layout* rhs);
 
+    //return an increffed lowercase conversion layout of l
+    static layout* lower(layout *l);
+
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.
     static layout* getitem(layout* lhs, int64_t offset);

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -26,6 +26,18 @@ extern "C" {
         return String::lower(l);
     }
 
+    int64_t nativepython_runtime_string_find(String::layout* l, String::layout* sub, int64_t start, int64_t end) {
+        return String::find(l, sub, start, end);
+    }
+
+    int64_t nativepython_runtime_string_find_2(String::layout* l, String::layout* sub) {
+        return String::find_2(l, sub);
+    }
+
+    int64_t nativepython_runtime_string_find_3(String::layout* l, String::layout* sub, int64_t start) {
+        return String::find_3(l, sub, start);
+    }
+
     String::layout* nativepython_runtime_string_getitem_int64(String::layout* lhs, int64_t index) {
         return String::getitem(lhs, index);
     }

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -22,6 +22,10 @@ extern "C" {
         return String::concatenate(lhs, rhs);
     }
 
+    String::layout* nativepython_runtime_string_lower(String::layout* l) {
+        return String::lower(l);
+    }
+
     String::layout* nativepython_runtime_string_getitem_int64(String::layout* lhs, int64_t index) {
         return String::getitem(lhs, index);
     }

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -171,7 +171,7 @@ class RandomValueProducer:
 
 class NativeTypesTests(unittest.TestCase):
 
-    def check_expected_performance(self, elapsed, expected=1.0):
+    def check_expected_performance(self, elapsed, expected=1.5):
         if os.environ.get('TRAVIS_CI', None) is not None:
             expected = 2 * expected
 


### PR DESCRIPTION
* Compile str.lower() into C++
* For String: For 3-byte UTF-8 characters, which are 16 bits, adjust bytes per codepoint required from 4 to 2