### PR TITLE
Compile str.lower() to C++

### DIFF
--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -27,9 +27,9 @@ someStrings = [
     "a",
     "as\x00df",
     "\u00F1",
-    "\u0F01",
-    "\u0F01",
-    "\u1002"
+    "\u007F\u0080\u0081\u07FF",
+    "\u0800\u0801\uFFFF",
+    "\U00010000\U00010001\U0010FFFF"
 ]
 
 for s1 in list(someStrings):
@@ -137,12 +137,37 @@ class TestStringCompilation(unittest.TestCase):
                 self.assertEqual(callOrExcept(getitem, s, i), callOrExcept(lambda s, i: s[i], s, i), (s, i))
 
 
-    def test_string_lower(self):
+    def test_string__lower(self):
 
         @Compiled
         def c_lower(s: str):
             return s.lower()
 
-        someupper_strings = ["Abc","aBc","abC", "ABC","\u00CA\u00D1\u011A\u1E66\u1EEA","XyZ\U0001D471"]
+        @Compiled
+        def c_lower2(s: str, t: str):
+            return s.lower(t)
+
+        def callOrExceptType(f, *args):
+            try:
+                return ("Normal", f(*args))
+            except Exception as e:
+                return ("Exception", str(type(e)))
+
+        someupper_strings = [
+            "abc"
+            "Abc",
+            "aBc",
+            "abC",
+            "ABC",
+            "aBcDeFgHiJkLm" *10000,
+            "\u00CA\u00D1\u011A\u1E66\u1EEA",
+            "\u00CA\u00D1\u011A\u1E66\u1EEA" *10000,
+            "XyZ\U0001D471",
+            "XyZ\U0001D471" *10000,
+            "\u007F\u0080\u0081\u07FF\u0800\u0801\uFFFF\U00010000\U00010001\U0010FFFF"
+        ]
         for s in someupper_strings:
-            self.assertEqual(s.lower(), c_lower(s))
+            self.assertEqual(c_lower(s), s.lower())
+
+        for s in someupper_strings:
+            self.assertEqual(callOrExceptType(c_lower2, s, s), callOrExceptType(s.lower, s))

--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -135,3 +135,14 @@ class TestStringCompilation(unittest.TestCase):
         for s in someStrings:
             for i in range(-20, 20):
                 self.assertEqual(callOrExcept(getitem, s, i), callOrExcept(lambda s, i: s[i], s, i), (s, i))
+
+
+    def test_string_lower(self):
+
+        @Compiled
+        def c_lower(s: str):
+            return s.lower()
+
+        someupper_strings = ["Abc","aBc","abC", "ABC","\u00CA\u00D1\u011A\u1E66\u1EEA","XyZ\U0001D471"]
+        for s in someupper_strings:
+            self.assertEqual(s.lower(), c_lower(s))

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -131,6 +131,12 @@ string_from_utf8_and_len = externalCallTarget(
     UInt8Ptr, Int64
 )
 
+string_lower = externalCallTarget(
+    "nativepython_runtime_string_lower",
+    Void.pointer(),
+    Void.pointer()
+)
+
 bytes_concat = externalCallTarget(
     "nativepython_runtime_bytes_concat",
     Void.pointer(),

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -150,15 +150,14 @@ class StringWrapper(RefcountedWrapper):
             return super().convert_method_call(context, instance, methodname, args, kwargs)
 
         if methodname == "lower":
-            if len(args) != 0:
-                    return
-            return context.push(
-                str,
-                lambda strRef: strRef.expr.store(
-                    runtime_functions.string_lower.call(
-                        instance.nonref_expr.cast(VoidPtr)
-                    ).cast(self.layoutType)
+            if len(args) == 0:
+                return context.push(
+                    str,
+                    lambda strRef: strRef.expr.store(
+                        runtime_functions.string_lower.call(
+                            instance.nonref_expr.cast(VoidPtr)
+                        ).cast(self.layoutType)
+                    )
                 )
-            )
 
         return super().convert_method_call(context, instance, methodname, args, kwargs)

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -82,6 +82,37 @@ String::layout* String::concatenate(layout* lhs, layout* rhs) {
     return new_layout;
 }
 
+String::layout* String::lower(layout *l) {
+    if (!l) {
+        return l;
+    }
+
+    int64_t new_byteCount = sizeof(layout) + l->pointcount * l->bytes_per_codepoint;
+    layout* new_layout = (layout*)malloc(new_byteCount);
+    new_layout->refcount = 1;
+    new_layout->hash_cache = -1;
+    new_layout->bytes_per_codepoint = l->bytes_per_codepoint;
+    new_layout->pointcount = l->pointcount;
+
+    if (l->bytes_per_codepoint == 1) {
+        for (uint8_t *src = l->data, *dest = new_layout->data, *end = src + l->pointcount; src < end; ) {
+            *dest++ = (uint8_t)tolower(*src++);
+        }
+    }
+    else if (l->bytes_per_codepoint == 2) {
+        for (uint16_t *src = (uint16_t *)l->data, *dest = (uint16_t *)new_layout->data, *end = src + l->pointcount; src < end; ) {
+            *dest++ = (uint16_t)towlower(*src++);
+        }
+    }
+    else if (l->bytes_per_codepoint == 4) {
+        for (uint32_t *src = (uint32_t *)l->data, *dest = (uint32_t *)new_layout->data, *end = src + l->pointcount; src < end; ) {
+            *dest++ = (uint32_t)towlower(*src++);
+        }
+    }
+
+    return new_layout;
+}
+
 String::layout* String::getitem(layout* lhs, int64_t offset) {
     if (!lhs) {
         return lhs;
@@ -136,7 +167,7 @@ int64_t String::bytesPerCodepointRequiredForUtf8(const uint8_t* utf8Str, int64_t
         if (utf8Str[0] >> 4 == 0b1110) {
             length -= 1;
             utf8Str += 3;
-            bytes_per_codepoint = std::max<int64_t>(4, bytes_per_codepoint);
+            bytes_per_codepoint = std::max<int64_t>(2, bytes_per_codepoint);
         }
 
         if (utf8Str[0] >> 3 == 0b11110) {

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -34,6 +34,9 @@ public:
     //return an increffed concatenated layout of lhs and rhs
     static layout* concatenate(layout* lhs, layout* rhs);
 
+    //return an increffed lowercase conversion layout of l
+    static layout* lower(layout *l);
+
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.
     static layout* getitem(layout* lhs, int64_t offset);

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -22,6 +22,10 @@ extern "C" {
         return String::concatenate(lhs, rhs);
     }
 
+    String::layout* nativepython_runtime_string_lower(String::layout* l) {
+        return String::lower(l);
+    }
+
     String::layout* nativepython_runtime_string_getitem_int64(String::layout* lhs, int64_t index) {
         return String::getitem(lhs, index);
     }

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -171,7 +171,7 @@ class RandomValueProducer:
 
 class NativeTypesTests(unittest.TestCase):
 
-    def check_expected_performance(self, elapsed, expected=1.0):
+    def check_expected_performance(self, elapsed, expected=1.5):
         if os.environ.get('TRAVIS_CI', None) is not None:
             expected = 2 * expected
 

--- a/typed_python/types_test.py
+++ b/typed_python/types_test.py
@@ -171,7 +171,7 @@ class RandomValueProducer:
 
 class NativeTypesTests(unittest.TestCase):
 
-    def check_expected_performance(self, elapsed, expected=1.5):
+    def check_expected_performance(self, elapsed, expected=1.0):
         if os.environ.get('TRAVIS_CI', None) is not None:
             expected = 2 * expected
 


### PR DESCRIPTION

## Motivation and Context
* New feature: Compile str.lower() to C++ 
* Improvement: Characters that need 3 bytes to represent in UTF-8 need only 2 bytes in our String representation (rather than 4).

## Approach
* Implemented C++ function on type String, defined runtime function to call from python, and when compiling, create the appropriate call in String wrapper.

## How Has This Been Tested?
* str.lower() is compiled and tested with various UTF-8 ranges
* str.lower() is tested with too many arguments, asserted to generate same TypeError as python code.
* General test strings for all string functions have been adjusted to include more UTF-8 boundary cases.
