### PR TITLE
Compile str.find()

### DIFF
--- a/nativepython/tests/string_compilation_test.py
+++ b/nativepython/tests/string_compilation_test.py
@@ -21,7 +21,6 @@ def Compiled(f):
     f = Function(f)
     return Runtime.singleton().compile(f)
 
-
 someStrings = [
     "",
     "a",
@@ -36,6 +35,13 @@ for s1 in list(someStrings):
     for s2 in list(someStrings):
         someStrings.append(s1+s2)
 someStrings = sorted(set(someStrings))
+
+
+def callOrExceptType(f, *args):
+    try:
+        return ("Normal", f(*args))
+    except Exception as e:
+        return ("Exception", str(type(e)))
 
 
 class TestStringCompilation(unittest.TestCase):
@@ -136,7 +142,7 @@ class TestStringCompilation(unittest.TestCase):
             for i in range(-20, 20):
                 self.assertEqual(callOrExcept(getitem, s, i), callOrExcept(lambda s, i: s[i], s, i), (s, i))
 
-    def test_string__lower(self):
+    def test_string_lower(self):
 
         @Compiled
         def c_lower(s: str):
@@ -145,12 +151,6 @@ class TestStringCompilation(unittest.TestCase):
         @Compiled
         def c_lower2(s: str, t: str):
             return s.lower(t)
-
-        def callOrExceptType(f, *args):
-            try:
-                return ("Normal", f(*args))
-            except Exception as e:
-                return ("Exception", str(type(e)))
 
         someupper_strings = [
             "abc"
@@ -170,3 +170,102 @@ class TestStringCompilation(unittest.TestCase):
 
         for s in someupper_strings:
             self.assertEqual(callOrExceptType(c_lower2, s, s), callOrExceptType(s.lower, s))
+
+    def test_string__find(self):
+
+        @Compiled
+        def c_find(s: str, sub: str, start: int, end: int):
+            return s.find(sub, start, end)
+
+        @Compiled
+        def c_find_3(s: str, sub: str, start: int):
+            return s.find(sub, start)
+
+        @Compiled
+        def c_find_2(s: str, sub: str):
+            return s.find(sub)
+
+        def test_find(t):
+            substrings = ["", "x", "xyz", "a"*100, t[0:-2] + t[-1] if len(t) > 2 else ""]
+            for start in range(0,min(len(t),8)):
+                for end in range(start+1,min(len(t),8)+1):
+                    substrings.append(t[start:end])
+
+            indexrange = [
+                -(len(t)+1)*256,
+                -len(t)-1, -len(t), -len(t)+1,
+                -len(t)//2-1, -len(t)//2, -len(t)//2+1,
+                -2, -1, 0, 1, 2,
+                len(t)//2-1, len(t)//2, len(t)//2+1,
+                len(t)-3, len(t)-2, len(t)-1, len(t), len(t)+1,
+                (len(t)+1)*256
+            ]
+            indexrange = sorted(set(indexrange))
+            for sub in substrings:
+                for start in indexrange:
+                    for end in indexrange:
+                        i = t.find(sub, start, end)
+                        c_i = c_find(t, sub, start, end)
+                        if i != c_i:
+                            self.assertEqual(i, c_i)
+                        self.assertEqual(i, c_i)
+            for sub in substrings:
+                for start in indexrange:
+                    i = t.find(sub, start)
+                    c_i = c_find_3(t, sub, start)
+                    self.assertEqual(i, c_i)
+            for sub in substrings:
+                i = t.find(sub)
+                c_i = c_find_2(t, sub)
+                self.assertEqual(i, c_i)
+
+        test_find("")
+        test_find("a")
+        test_find("abcdef")
+        test_find("baaaab")
+        test_find(("a"*99 + "b")*100)
+        test_find("\u00CA\u00D1\u011A\u1E66\u1EEA")
+        test_find("\u00DD\U00012EEE\U0001D471\u00AA\U00011234")
+
+        @Compiled
+        def c_find_1(s: str):
+            return s.find()
+
+        @Compiled
+        def c_find_5(s: str, sub: str, start: int, end: int, extra: int):
+            return s.find(str, start, end, extra)
+
+        for s in ["a", ""]:
+            self.assertEqual(callOrExceptType(c_find_5, s, s, 0, 1, 2), callOrExceptType(s.find, s, 0, 1, 2))
+            self.assertEqual(callOrExceptType(c_find_1, s), callOrExceptType(s.find))
+
+        """
+        def rep_find(s, subs):
+            result = 0
+            for i in range(1000):
+                for sub in subs:
+                    result += s.find(sub)
+            return result
+
+        @Compiled
+        def c_rep_find(s: str, subs: ListOf(str)) -> int:
+            result = 0
+            for i in range(1000):
+                for sub in subs:
+                    result += s.find(sub)
+            return result
+
+        def test_find_perf(f, s, subs):
+            t0 = time.time()
+            f(s,subs)
+            return time.time() - t0
+
+        s = "a" * 100000 + "b" + "a" * 100000
+        subs = ["aaa", "aba","aab","baa", "bbb"]
+        c_elapsed = test_find_perf(c_rep_find, s, subs)
+        elapsed = test_find_perf(rep_find, s, subs)
+        self.assertTrue(c_elapsed < elapsed,
+                "Slow Performance: compiled took {0} sec versus baseline {1}"
+                .format(c_elapsed, elapsed)
+        )
+        """

--- a/nativepython/type_wrappers/runtime_functions.py
+++ b/nativepython/type_wrappers/runtime_functions.py
@@ -137,6 +137,24 @@ string_lower = externalCallTarget(
     Void.pointer()
 )
 
+string_find = externalCallTarget(
+    "nativepython_runtime_string_find",
+    Int64,
+    Void.pointer(), Void.pointer(), Int64, Int64
+)
+
+string_find_2 = externalCallTarget(
+    "nativepython_runtime_string_find_2",
+    Int64,
+    Void.pointer(), Void.pointer()
+)
+
+string_find_3 = externalCallTarget(
+    "nativepython_runtime_string_find_3",
+    Int64,
+    Void.pointer(), Void.pointer(), Int64
+)
+
 bytes_concat = externalCallTarget(
     "nativepython_runtime_bytes_concat",
     Void.pointer(),

--- a/nativepython/type_wrappers/string_wrapper.py
+++ b/nativepython/type_wrappers/string_wrapper.py
@@ -13,6 +13,9 @@
 #   limitations under the License.
 
 from nativepython.type_wrappers.refcounted_wrapper import RefcountedWrapper
+from typed_python import Int64
+from nativepython.type_wrappers.arithmetic_wrapper import Int64Wrapper
+
 import nativepython.type_wrappers.runtime_functions as runtime_functions
 from nativepython.type_wrappers.bound_compiled_method_wrapper import BoundCompiledMethodWrapper
 
@@ -140,7 +143,7 @@ class StringWrapper(RefcountedWrapper):
         )
 
     def convert_attribute(self, context, instance, attr):
-        if attr in ("lower",):
+        if attr in ("lower", "find"):
             return instance.changeType(BoundCompiledMethodWrapper(self, attr))
 
         return super().convert_attribute(context, instance, attr)
@@ -157,6 +160,40 @@ class StringWrapper(RefcountedWrapper):
                         runtime_functions.string_lower.call(
                             instance.nonref_expr.cast(VoidPtr)
                         ).cast(self.layoutType)
+                    )
+                )
+        elif methodname == "find":
+            if len(args) == 1:
+                return context.push(
+                    Int64,
+                    lambda iRef: iRef.expr.store(
+                        runtime_functions.string_find_2.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            args[0].nonref_expr.cast(VoidPtr)
+                        )
+                    )
+                )
+            elif len(args) == 2:
+                return context.push(
+                    Int64,
+                    lambda iRef: iRef.expr.store(
+                        runtime_functions.string_find_3.call(
+                            instance.nonref_expr.cast(VoidPtr),
+                            args[0].nonref_expr.cast(VoidPtr),
+                            args[1].nonref_expr
+                        )
+                    )
+                )
+            elif len(args) == 3:
+                return context.push(
+                    Int64,
+                    lambda iRef: iRef.expr.store(
+                        runtime_functions.string_find.call(
+                        instance.nonref_expr.cast(VoidPtr),
+                        args[0].nonref_expr.cast(VoidPtr),
+                        args[1].nonref_expr,
+                        args[2].nonref_expr
+                        )
                     )
                 )
 

--- a/typed_python/StringType.cpp
+++ b/typed_python/StringType.cpp
@@ -1,4 +1,6 @@
 #include "AllTypes.hpp"
+#include  <iostream>
+using namespace std;
 
 String::layout* String::upgradeCodePoints(layout* lhs, int32_t newBytesPerCodepoint) {
     if (!lhs) {
@@ -113,6 +115,64 @@ String::layout* String::lower(layout *l) {
     return new_layout;
 }
 
+int64_t String::find_2(layout *l, layout *sub) {
+    return find(l, sub, 0, l ? l->pointcount : 0);
+}
+
+int64_t String::find_3(layout *l, layout *sub, int64_t start) {
+    return find(l, sub, start, l ? l->pointcount : 0);
+}
+
+int64_t String::find(layout *l, layout *sub, int64_t start, int64_t end) {
+
+    auto getpoint = [] (layout *a, int64_t i) -> int32_t {
+        if (a->bytes_per_codepoint == 1)
+            return ((uint8_t *)a->data)[i];
+        else if (a->bytes_per_codepoint == 2)
+            return ((uint16_t *)a->data)[i];
+        else if (a->bytes_per_codepoint == 4)
+            return ((uint32_t *)a->data)[i];
+    };
+
+    if (!l || !l->pointcount) {
+        if (!sub || !sub->pointcount)
+            return start > 0 ? -1 : 0;
+        return -1;
+    }
+    if (start < 0) {
+        start += l->pointcount;
+        if (start < 0) start = 0;
+    }
+    if (end < 0) {
+        end += l->pointcount;
+        if (end < 0) end = 0;
+    }
+    if (end < start || start > l->pointcount)
+        return -1;
+    if (!sub || !sub->pointcount)
+        return start >= 0 ? start : 0;
+
+    if (end > l->pointcount)
+        end = l->pointcount;
+    end -= (sub->pointcount - 1);
+    if (start < 0 || end < 0 || start >= end || sub->pointcount > l->pointcount || start > l->pointcount - sub->pointcount)
+        return -1;
+
+    for (int64_t i = start; i < end; i++) {
+        bool match = true;
+        for (int64_t j = 0; j < sub->pointcount; j++) {
+            if (getpoint(l, i+j) != getpoint(sub, j)) {
+                match = false;
+                break;
+            }
+        }
+        if (match)
+            return i;
+    }
+
+    return -1;
+}
+
 String::layout* String::getitem(layout* lhs, int64_t offset) {
     if (!lhs) {
         return lhs;
@@ -137,13 +197,13 @@ String::layout* String::getitem(layout* lhs, int64_t offset) {
 
     //we could figure out if we can represent this with a smaller encoding.
     if (new_layout->bytes_per_codepoint == 1) {
-        ((int8_t*)new_layout->data)[0] = ((int8_t*)lhs->data)[offset];
+        ((uint8_t*)new_layout->data)[0] = ((uint8_t*)lhs->data)[offset];
     }
     if (new_layout->bytes_per_codepoint == 2) {
-        ((int16_t*)new_layout->data)[0] = ((int16_t*)lhs->data)[offset];
+        ((uint16_t*)new_layout->data)[0] = ((uint16_t*)lhs->data)[offset];
     }
     if (new_layout->bytes_per_codepoint == 4) {
-        ((int32_t*)new_layout->data)[0] = ((int32_t*)lhs->data)[offset];
+        ((uint32_t*)new_layout->data)[0] = ((uint32_t*)lhs->data)[offset];
     }
 
     return new_layout;

--- a/typed_python/StringType.hpp
+++ b/typed_python/StringType.hpp
@@ -37,6 +37,11 @@ public:
     //return an increffed lowercase conversion layout of l
     static layout* lower(layout *l);
 
+    //return the lowest index in the string where substring sub is found within l[start, end]
+    static int64_t find(layout* l, layout* sub, int64_t start, int64_t end);
+    static int64_t find_2(layout* l, layout* sub);
+    static int64_t find_3(layout* l, layout* sub, int64_t start);
+
     //return an increffed string containing the one codepoint at 'offset'. this function
     //will correctly map negative indices, but performs no other boundschecking.
     static layout* getitem(layout* lhs, int64_t offset);

--- a/typed_python/_runtime.cpp
+++ b/typed_python/_runtime.cpp
@@ -26,6 +26,18 @@ extern "C" {
         return String::lower(l);
     }
 
+    int64_t nativepython_runtime_string_find(String::layout* l, String::layout* sub, int64_t start, int64_t end) {
+        return String::find(l, sub, start, end);
+    }
+
+    int64_t nativepython_runtime_string_find_2(String::layout* l, String::layout* sub) {
+        return String::find_2(l, sub);
+    }
+
+    int64_t nativepython_runtime_string_find_3(String::layout* l, String::layout* sub, int64_t start) {
+        return String::find_3(l, sub, start);
+    }
+
     String::layout* nativepython_runtime_string_getitem_int64(String::layout* lhs, int64_t index) {
         return String::getitem(lhs, index);
     }


### PR DESCRIPTION
## Motivation and Context
* New feature: compile str.find() to C++

## Approach
* Implemented C++ functions of type String, one for each possible number of parameters, e.g. str.find(s, sub), str.find(s, sub, start), and str.find(s,sub, start, end)
* Defined corresponding runtime functions to call from python, and when compiling, create the appropriate call in String wrapper, according to the number of arguments provided.
* Functionality is there, but not necessarily performant, at least in the tests I've done so far.

## How Has This Been Tested?
* Tested on empty, small, and large base strings and substrings.
* Vary start and end over a wide range of values.
* Test too few and too many arguments. Raise TypeError in these cases.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
