### PR TITLE
Use official name of beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 flask
 boto3
-bs4
+beautifulsoup4
 flask
 flask_cors
 flask-login


### PR DESCRIPTION
## Motivation and Context
bs4 is a dummy package to prevent squatting the name, but beautifulsoup4
is the official name of the package, and we were using that name in the
Pipfile, so let's be consistent and avoid the dummy dependency.

## Approach
renamed bs4 -> beautifulsoup4 in `requirements.txt`
