### PR TITLE
Ignore .eggs dir created by new setup when linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ nativepython.egg-info
 /testcert.key
 /testcert.cert
 /.venv
+/.eggs
+

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ ignore =
     E227,  # missing whitespace around bitwise or shift operator
     E228,  # missing whitespace around modulo operator
     E731,  # do not assign a lambda expression, use a def
-exclude = 
+exclude =
     .git,
     .venv,
     build,
@@ -24,8 +24,9 @@ ignore =
     E227,  # missing whitespace around bitwise or shift operator
     E228,  # missing whitespace around modulo operator
     E731,  # do not assign a lambda expression, use a def
-exclude = 
+exclude =
     .git,
+    .eggs,
     .venv,
     build,
     nativepython.egg-info


### PR DESCRIPTION
## Motivation and Context
New and improved setup.py creates an `.eggs` directory. Ignore it when linting and when running `git status`

## Approach
Add `.eggs` to `.gitignore` and to `tox.ini`

## How Has This Been Tested?
Manually ran the following commands with the repo checked out at this commit and checked I didn't get any lint errors and any `git status`  output:

```
make clean
make install
[check that I have a new .eggs dir]
make lint
git status
```
