### PR TITLE
fix missing <memory> import in SerializationContext

### DIFF
--- a/typed_python/SerializationContext.hpp
+++ b/typed_python/SerializationContext.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 class SerializationBuffer;
 class DeserializationBuffer;
 


### PR DESCRIPTION
This fixes a compilation error

```
In file included from typed_python/Type.hpp:16:
typed_python/SerializationContext.hpp:46:18: error: no template named 'shared_ptr' in namespace 'std'
    virtual std::shared_ptr<ByteBuffer> compress(uint8_t* begin, uint8_t* end) const = 0;
            ~~~~~^
typed_python/SerializationContext.hpp:47:18: error: no template named 'shared_ptr' in namespace 'std'
    virtual std::shared_ptr<ByteBuffer> decompress(uint8_t* begin, uint8_t* end) const = 0;
            ~~~~~^
```

I'm using Ubuntu 18.04.2 LTS with g++ (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0