### PR TITLE
HTML Generation

### DIFF
--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -893,7 +893,7 @@ class Card(Cell):
         body = HTMLElement.div().add_class(
             "card-body").add_class(
                 other).add_child(
-                    HTMLTextContent("____contents__"))
+                    HTMLTextContent(" ____contents__"))
         card = HTMLElement.div().add_class("card")
 
         if self.header is not None:
@@ -907,6 +907,8 @@ class Card(Cell):
         card.add_child(body)
         card.attributes["style"] = self._divStyle()
 
+        self.cells._logger.info(str(card))
+        
         self.contents = str(card)
 
     def sortsAs(self):

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -15,6 +15,7 @@ from inspect import signature
 from object_database.view import RevisionConflictException
 from object_database.view import current_transaction
 from object_database.util import Timer
+from object_database.web.html.html_gen import HTMLElement, HTMLTextContent
 
 MAX_TIMEOUT = 1.0
 MAX_TRIES = 10
@@ -885,28 +886,28 @@ class Card(Cell):
     def recalculate(self):
         self.children = {"____contents__": Cell.makeCell(self.body)}
 
-        if self.header is not None:
-            self.children['____header__'] = Cell.makeCell(self.header)
-
         other = ""
         if self.padding:
             other += " p-" + str(self.padding)
 
-        self.contents = ("""
-            <div class="card" __style__>
-              __header__
-              <div class="card-body __other__">
-                ____contents__
-              </div>
-            </div>
-            """.replace('__other__', other)
-               .replace('__style__', self._divStyle())
-               .replace("__header__", """
-                    <div class="card-header">
-                        ____header__
-                    </div>
-                """ if self.header is not None else "")
-        )
+        body = HTMLElement.div().add_class(
+            "card-body").add_class(
+                other).add_child(
+                    HTMLTextContent("____contents__"))
+        card = HTMLElement.div().add_class("card")
+
+        if self.header is not None:
+            header = HTMLElement.div().add_class(
+                "card-header").add_child(
+                    HTMLTextContent("____header__")
+            )
+            self.children['____header__'] = Cell.makeCell(self.header)
+            card.add_child(header)
+
+        card.add_child(body)
+        card.attributes["style"] = self._divStyle()
+
+        self.contents = str(card)
 
     def sortsAs(self):
         return self.contents.sortsAs()

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -908,7 +908,7 @@ class Card(Cell):
         card.attributes["style"] = self._divStyle()
 
         self.cells._logger.info(str(card))
-        
+
         self.contents = str(card)
 
     def sortsAs(self):
@@ -920,11 +920,9 @@ class CardTitle(Cell):
         super().__init__()
 
         self.children = {"____contents__": Cell.makeCell(inner)}
-        self.contents = """
-        <div class='card-title'>
-          ____contents__
-        </div>
-        """
+        self.contents = HTMLElement.div().add_child(
+            HTMLTextContent("____contents__")
+        ).add_class("card-title")
 
     def sortsAs(self):
         return self.inner.sortsAs()
@@ -1011,28 +1009,27 @@ class CollapsiblePanel(Cell):
 
     def recalculate(self):
         expanded = self.evaluateWithDependencies(self.isExpanded)
-
-        self.contents = """
-            <div class="container-fluid" __style__>
-                <div class="row flex-nowrap no-gutters">
-                    <div class="col-md-auto">
-                        ____panel__
-                    </div>
-                    <div class="col-sm">
-                        ____content__
-                    </div>
-                </div>
-            </div>
-            """ if expanded else """
-            <div __style__>
-                ____content__
-            </div>
-            """
-
-        self.contents = (
-            self.contents.replace("__identity__", self.identity)
-                         .replace("__style__", self._divStyle())
-        )
+        if expanded:
+            container = HTMLElement.div().add_class("container-fluid")
+            container.attributes["style"] = self._divStyle()
+            row = HTMLElement.div().add_classes(
+                 ["row", "flex-nowrap", "no-gutters"]
+            ).with_children(
+                HTMLElement.div().add_class("col-md-auto").add_child(
+                    HTMLTextContent("____panel__")
+                ),
+                HTMLElement.div().add_class("col-sm").add_child(
+                    HTMLTextContent("____content__")
+                )
+            )
+            container.add_child(row)
+            self.contents = str(container)
+        else:
+            unexpanded_container = HTMLElement.div().add_child(
+                HTMLTextContent("____content__")
+            )
+            unexpanded_container.attributes['style'] = self._divStyle()
+            self.contents = str(unexpanded_container)
 
         self.children = {
             '____content__': self.content

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -82,7 +82,8 @@ def multiReplace(msg, replacements):
         else:
             outChunks.append("____" + chunk)
 
-    assert not replacements, "Didn't use up replacement %s in %s" % (replacements.keys(), msg)
+    assert not replacements, "Didn't use up replacement %s in %s" % (
+        replacements.keys(), msg)
 
     return "".join(outChunks)
 
@@ -109,7 +110,8 @@ class GeventPipe:
 
     def __init__(self):
         self.read_fd, self.write_fd = os.pipe()
-        self.fileobj = gevent.fileobject.FileObjectPosix(self.read_fd, bufsize=2)
+        self.fileobj = gevent.fileobject.FileObjectPosix(
+            self.read_fd, bufsize=2)
         self.netChange = 0
 
     def wait(self):
@@ -208,13 +210,16 @@ class Cells:
             creatingCell, task = self._tasks.get(timeout=.25)
             if creatingCell.isActive():
                 try:
-                    self._logger.info("Starting task %s with %s remaining", task, self._tasks.qsize())
+                    self._logger.info(
+                        "Starting task %s with %s remaining", task, self._tasks.qsize())
                     t0 = time.time()
                     _cur_cell.isProcessingTask = True
                     task(creatingCell, self._shouldStopProcessingTasks)
-                    self._logger.info("Task %s took %s", task, time.time() - t0)
+                    self._logger.info("Task %s took %s",
+                                      task, time.time() - t0)
                 except Exception:
-                    self._logger.error("Unexpected Exception in cells.processTasks:\n%s", traceback.format_exc())
+                    self._logger.error(
+                        "Unexpected Exception in cells.processTasks:\n%s", traceback.format_exc())
                 finally:
                     _cur_cell.isProcessingTask = False
             return True
@@ -312,12 +317,14 @@ class Cells:
                 del self._subscribedCells[subscription]
 
     def markDirty(self, cell):
-        assert not cell.garbageCollected, (cell, cell.text if isinstance(cell, Text) else "")
+        assert not cell.garbageCollected, (cell, cell.text if isinstance(
+            cell, Text) else "")
 
         self._dirtyNodes.add(cell)
 
     def markToDiscard(self, cell):
-        assert not cell.garbageCollected, (cell, cell.text if isinstance(cell, Text) else "")
+        assert not cell.garbageCollected, (cell, cell.text if isinstance(
+            cell, Text) else "")
 
         self._nodesToDiscard.add(cell)
 
@@ -353,7 +360,8 @@ class Cells:
         # here to happen in order, because they're triggered by messages,
         # so we have to reverse the order in which we append them, and
         # put them on the front.
-        res = [{'postscript': js} for js in reversed(self._pendingPostscripts)] + res
+        res = [{'postscript': js}
+               for js in reversed(self._pendingPostscripts)] + res
 
         self._pendingPostscripts.clear()
 
@@ -411,9 +419,12 @@ class Cells:
                             child_cell.prepareForReuse()
 
                 except Exception:
-                    self._logger.error("Node %s had exception during recalculation:\n%s", n, traceback.format_exc())
-                    self._logger.error("Subscribed cell threw an exception:\n%s", traceback.format_exc())
-                    n.children = {'____contents__': Traceback(traceback.format_exc())}
+                    self._logger.error(
+                        "Node %s had exception during recalculation:\n%s", n, traceback.format_exc())
+                    self._logger.error(
+                        "Subscribed cell threw an exception:\n%s", traceback.format_exc())
+                    n.children = {'____contents__': Traceback(
+                        traceback.format_exc())}
                     n.contents = "____contents__"
                 finally:
                     _cur_cell.cell = None
@@ -432,20 +443,23 @@ class Cells:
 
     def updateMessageFor(self, cell):
         contents = cell.contents
-        assert isinstance(contents, str), "Cell %s produced %s for its contents which is not a string" % (cell, contents)
+        assert isinstance(
+            contents, str), "Cell %s produced %s for its contents which is not a string" % (cell, contents)
 
         formatArgs = {}
 
         replaceDict = {}
 
         for childName, childNode in cell.children.items():
-            formatArgs[childName] = "<div id='%s'></div>" % (cell.identity + "_" + childName)
+            formatArgs[childName] = "<div id='%s'></div>" % (
+                cell.identity + "_" + childName)
             replaceDict[cell.identity + "_" + childName] = childNode.identity
 
         try:
             contents = multiReplace(contents, formatArgs)
         except Exception:
-            raise Exception("Failed to format these contents with args %s:\n\n%s", formatArgs, contents)
+            raise Exception(
+                "Failed to format these contents with args %s:\n\n%s", formatArgs, contents)
 
         res = {
             'id': cell.identity,
@@ -470,6 +484,7 @@ class Slot:
     UX state when we navigate away. We could also keep this in ODB so that
     the state is preserved when we bounce the page.
     """
+
     def __init__(self, value=None):
         self._value = value
         self._pendingValue = value
@@ -551,6 +566,7 @@ class SessionState(object):
     """Represents a piece of session-specific interface state. You may access state
     using attributes, which will register a dependency
     """
+
     def __init__(self):
         self._slots = {}
 
@@ -566,7 +582,8 @@ class SessionState(object):
                 try:
                     s._value.prepareForReuse()
                 except Exception:
-                    logging.warn("Reusing a Cell slot could create a problem: %s", s._value)
+                    logging.warn(
+                        "Reusing a Cell slot could create a problem: %s", s._value)
 
     def _slotFor(self, name):
         if name not in self._slots:
@@ -662,7 +679,8 @@ class Cell:
             return cells
 
         for child in self.children:
-            cells.extend(self.children[child].findChildrenByTag(tag, stopSearchingAtTag, False))
+            cells.extend(self.children[child].findChildrenByTag(
+                tag, stopSearchingAtTag, False))
 
         return cells
 
@@ -704,10 +722,12 @@ class Cell:
             except RevisionConflictException:
                 tries += 1
                 if tries > MAX_TRIES or time.time() - t0 > MAX_TIMEOUT:
-                    self._logger.error("OnMessage timed out. This should really fail.")
+                    self._logger.error(
+                        "OnMessage timed out. This should really fail.")
                     return
             except Exception:
-                self._logger.error("Exception in dropdown logic:\n%s", traceback.format_exc())
+                self._logger.error(
+                    "Exception in dropdown logic:\n%s", traceback.format_exc())
                 return
             finally:
                 _cur_cell.cell = None
@@ -939,7 +959,8 @@ class Modal(Cell):
         super().__init__()
         self.title = title
         self.message = message
-        self.buttons = {f"____button_{k}__": Button(k, v) for k, v in buttonActions.items()}
+        self.buttons = {f"____button_{k}__": Button(
+            k, v) for k, v in buttonActions.items()}
 
     def recalculate(self):
         self.contents = (
@@ -1013,7 +1034,7 @@ class CollapsiblePanel(Cell):
             container = HTMLElement.div().add_class("container-fluid")
             container.attributes["style"] = self._divStyle()
             row = HTMLElement.div().add_classes(
-                 ["row", "flex-nowrap", "no-gutters"]
+                ["row", "flex-nowrap", "no-gutters"]
             ).with_children(
                 HTMLElement.div().add_class("col-md-auto").add_child(
                     HTMLTextContent("____panel__")
@@ -1079,7 +1100,8 @@ class Sequence(Cell):
         elements = [Cell.makeCell(x) for x in elements]
 
         self.elements = elements
-        self.children = {"____c_%s__" % i: elements[i] for i in range(len(elements)) }
+        self.children = {"____c_%s__" %
+                         i: elements[i] for i in range(len(elements))}
 
     def __add__(self, other):
         other = Cell.makeCell(other)
@@ -1089,7 +1111,8 @@ class Sequence(Cell):
             return Sequence(self.elements + [other])
 
     def recalculate(self):
-        self.contents = "<div %s>" % self._divStyle() + "\n".join("____c_%s__" % i for i in range(len(self.elements))) + "</div>"
+        self.contents = "<div %s>" % self._divStyle() + "\n".join("____c_%s__" %
+                                                                  i for i in range(len(self.elements))) + "</div>"
 
     def sortsAs(self):
         if self.elements:
@@ -1103,7 +1126,8 @@ class Columns(Cell):
         elements = [Cell.makeCell(x) for x in elements]
 
         self.elements = elements
-        self.children = {"____c_%s__" % i: elements[i] for i in range(len(elements)) }
+        self.children = {"____c_%s__" %
+                         i: elements[i] for i in range(len(elements))}
         self.contents = (
             """
             <div class="container-fluid" __style__>
@@ -1171,14 +1195,20 @@ class HeaderBar(Cell):
                 </div>
             </div>
         """ % (
-            "".join(["<span class='flex-item px-3'>____left_%s__</span>" % i for i in range(len(self.leftItems))]),
-            "".join(["<span class='flex-item px-3'>____center_%s__</span>" % i for i in range(len(self.centerItems))]),
-            "".join(["<span class='flex-item px-3'>____right_%s__</span>" % i for i in range(len(self.rightItems))]),
+            "".join(["<span class='flex-item px-3'>____left_%s__</span>" %
+                     i for i in range(len(self.leftItems))]),
+            "".join(["<span class='flex-item px-3'>____center_%s__</span>" %
+                     i for i in range(len(self.centerItems))]),
+            "".join(["<span class='flex-item px-3'>____right_%s__</span>" %
+                     i for i in range(len(self.rightItems))]),
         )
 
-        self.children = {'____left_%s__' % i: self.leftItems[i] for i in range(len(self.leftItems))}
-        self.children.update({'____center_%s__' % i: self.centerItems[i] for i in range(len(self.centerItems))})
-        self.children.update({'____right_%s__' % i: self.rightItems[i] for i in range(len(self.rightItems))})
+        self.children = {'____left_%s__' %
+                         i: self.leftItems[i] for i in range(len(self.leftItems))}
+        self.children.update(
+            {'____center_%s__' % i: self.centerItems[i] for i in range(len(self.centerItems))})
+        self.children.update(
+            {'____right_%s__' % i: self.rightItems[i] for i in range(len(self.rightItems))})
 
 
 class Main(Cell):
@@ -1236,10 +1266,12 @@ class Tabs(Cell):
         self.whichSlot.set(index)
 
     def recalculate(self):
-        self.children['____display__'] = Subscribed(lambda: self.headersAndChildren[self.whichSlot.get()][1])
+        self.children['____display__'] = Subscribed(
+            lambda: self.headersAndChildren[self.whichSlot.get()][1])
 
         for i in range(len(self.headersAndChildren)):
-            self.children['____header_{ix}__'.format(ix=i)] = _NavTab(self.whichSlot, i, self._identity, self.headersAndChildren[i][0])
+            self.children['____header_{ix}__'.format(ix=i)] = _NavTab(
+                self.whichSlot, i, self._identity, self.headersAndChildren[i][0])
 
         self.contents = (
             """
@@ -1287,7 +1319,8 @@ class Dropdown(Cell):
                     singleLambda(cell)
                 return callback
 
-            self.headersAndLambdas = [(header, makeCallback(header)) for header in headersAndLambdas]
+            self.headersAndLambdas = [(header, makeCallback(header))
+                                      for header in headersAndLambdas]
         else:
             self.headersAndLambdas = headersAndLambdas
 
@@ -1316,7 +1349,8 @@ class Dropdown(Cell):
                     "__onclick__",
                     "websocket.send(JSON.stringify({'event':'menu', 'ix': __ix__, 'target_cell': '__identity__'}))"
                     if not isinstance(onDropdown, str) else
-                    quoteForJs("window.location.href = '__url__'".replace("__url__", quoteForJs(onDropdown, "'")), '"')
+                    quoteForJs("window.location.href = '__url__'".replace(
+                        "__url__", quoteForJs(onDropdown, "'")), '"')
                 ).replace("__ix__", str(i)).replace("__identity__", self.identity)
             )
 
@@ -1348,7 +1382,8 @@ class Container(Cell):
             self.children = {"____child__": Cell.makeCell(child)}
 
     def setChild(self, child):
-        self.setContents("<div>____child__</div>", {"____child__": Cell.makeCell(child)})
+        self.setContents("<div>____child__</div>",
+                         {"____child__": Cell.makeCell(child)})
 
     def setContents(self, newContents, newChildren):
         self.contents = newContents
@@ -1470,8 +1505,10 @@ class Subscribed(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self.children = {'____contents__': Traceback(traceback.format_exc())}
-                self._logger.error("Subscribed inner function threw exception:\n%s", traceback.format_exc())
+                self.children = {'____contents__': Traceback(
+                    traceback.format_exc())}
+                self._logger.error(
+                    "Subscribed inner function threw exception:\n%s", traceback.format_exc())
 
             self._resetSubscriptionsToViewReads(v)
 
@@ -1506,7 +1543,8 @@ class SubscribedSequence(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error("Spine calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error(
+                    "Spine calc threw an exception:\n%s", traceback.format_exc())
                 self.spine = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -1514,14 +1552,17 @@ class SubscribedSequence(Cell):
             new_children = {}
             for ix, rowKey in enumerate(self.spine):
                 if rowKey in self.existingItems:
-                    new_children["____child_%s__" % ix] = self.existingItems[rowKey]
+                    new_children["____child_%s__" %
+                                 ix] = self.existingItems[rowKey]
                 else:
                     try:
-                        self.existingItems[rowKey] = new_children["____child_%s__" % ix] = self.makeCell(rowKey[0])
+                        self.existingItems[rowKey] = new_children["____child_%s__" % ix] = self.makeCell(
+                            rowKey[0])
                     except SubscribeAndRetry:
                         raise
                     except Exception:
-                        self.existingItems[rowKey] = new_children["____child_%s__" % ix] = Traceback(traceback.format_exc())
+                        self.existingItems[rowKey] = new_children["____child_%s__" % ix] = Traceback(
+                            traceback.format_exc())
 
         self.children = new_children
 
@@ -1550,7 +1591,8 @@ class SubscribedSequence(Cell):
         else:
             self.contents = """<div %s>%s</div>""" % (
                 self._divStyle(),
-                "\n".join(['____child_%s__' % i for i in range(len(self.spine))])
+                "\n".join(['____child_%s__' %
+                           i for i in range(len(self.spine))])
             )
 
 
@@ -1618,14 +1660,16 @@ class Grid(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error(
+                    "Row fun calc threw an exception:\n%s", traceback.format_exc())
                 self.rows = []
             try:
                 self.cols = augmentToBeUnique(self.colFun())
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error(
+                    "Col fun calc threw an exception:\n%s", traceback.format_exc())
                 self.cols = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -1636,7 +1680,8 @@ class Grid(Cell):
         for col_ix, col in enumerate(self.cols):
             seen.add((None, col))
             if (None, col) in self.existingItems:
-                new_children["____header_%s__" % (col_ix)] = self.existingItems[(None, col)]
+                new_children["____header_%s__" %
+                             (col_ix)] = self.existingItems[(None, col)]
             else:
                 try:
                     self.existingItems[(None, col)] = \
@@ -1653,7 +1698,8 @@ class Grid(Cell):
             for row_ix, row in enumerate(self.rows):
                 seen.add((None, row))
                 if (row, None) in self.existingItems:
-                    new_children["____rowlabel_%s__" % (row_ix)] = self.existingItems[(row, None)]
+                    new_children["____rowlabel_%s__" %
+                                 (row_ix)] = self.existingItems[(row, None)]
                 else:
                     try:
                         self.existingItems[(row, None)] = \
@@ -1863,7 +1909,8 @@ class Table(Cell):
             page = max(0, int(self.curPage.get())-1)
             page = min(page, (len(rows) - 1) // self.maxRowsPerPage)
         except Exception:
-            self._logger.error("Failed to parse current page: %s", traceback.format_exc())
+            self._logger.error(
+                "Failed to parse current page: %s", traceback.format_exc())
 
         return rows[page * self.maxRowsPerPage:(page+1) * self.maxRowsPerPage]
 
@@ -1878,11 +1925,13 @@ class Table(Cell):
                 return ""
             return Octicon("arrow-up" if not self.sortColumnAscending.get() else "arrow-down")
 
-        cell = Cell.makeCell(self.headerFun(col)).nowrap() + Padding() + Subscribed(icon).nowrap()
+        cell = Cell.makeCell(self.headerFun(col)).nowrap() + \
+            Padding() + Subscribed(icon).nowrap()
 
         def onClick():
             if self.sortColumn.get() == col_ix:
-                self.sortColumnAscending.set(not self.sortColumnAscending.get())
+                self.sortColumnAscending.set(
+                    not self.sortColumnAscending.get())
             else:
                 self.sortColumn.set(col_ix)
                 self.sortColumnAscending.set(False)
@@ -1890,10 +1939,12 @@ class Table(Cell):
         res = Clickable(cell, onClick, makeBold=True)
 
         if self.columnFilters[col].get() is None:
-            res = res.nowrap() + Clickable(Octicon("search"), lambda: self.columnFilters[col].set("")).nowrap()
+            res = res.nowrap() + Clickable(Octicon("search"),
+                                           lambda: self.columnFilters[col].set("")).nowrap()
         else:
             res = res + SingleLineTextBox(self.columnFilters[col]).nowrap() + \
-                Button(Octicon("x"), lambda: self.columnFilters[col].set(None), small=True)
+                Button(Octicon("x"), lambda: self.columnFilters[col].set(
+                    None), small=True)
 
         return Card(res, padding=1)
 
@@ -1904,7 +1955,8 @@ class Table(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error("Col fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error(
+                    "Col fun calc threw an exception:\n%s", traceback.format_exc())
                 self.cols = []
 
             try:
@@ -1915,7 +1967,8 @@ class Table(Cell):
             except SubscribeAndRetry:
                 raise
             except Exception:
-                self._logger.error("Row fun calc threw an exception:\n%s", traceback.format_exc())
+                self._logger.error(
+                    "Row fun calc threw an exception:\n%s", traceback.format_exc())
                 self.rows = []
 
             self._resetSubscriptionsToViewReads(v)
@@ -1926,7 +1979,8 @@ class Table(Cell):
         for col_ix, col in enumerate(self.cols):
             seen.add((None, col))
             if (None, col) in self.existingItems:
-                new_children["____header_%s__" % (col_ix)] = self.existingItems[(None, col)]
+                new_children["____header_%s__" %
+                             (col_ix)] = self.existingItems[(None, col)]
             else:
                 try:
                     self.existingItems[(None, col)] = \
@@ -1966,7 +2020,8 @@ class Table(Cell):
 
         totalPages = ((len(self.filteredRows) - 1) // self.maxRowsPerPage + 1)
 
-        rowDisplay = "____left__ ____right__ Page ____page__ of " + str(totalPages)
+        rowDisplay = "____left__ ____right__ Page ____page__ of " + \
+            str(totalPages)
         if totalPages <= 1:
             self.children['____page__'] = Cell.makeCell(totalPages).nowrap()
         else:
@@ -1977,7 +2032,8 @@ class Table(Cell):
                 .nowrap()
             )
         if self.curPage.get() == "1":
-            self.children['____left__'] = Octicon("triangle-left").nowrap().color("lightgray")
+            self.children['____left__'] = Octicon(
+                "triangle-left").nowrap().color("lightgray")
         else:
             self.children['____left__'] = (
                 Clickable(
@@ -1986,7 +2042,8 @@ class Table(Cell):
                 ).nowrap()
             )
         if self.curPage.get() == str(totalPages):
-            self.children['____right__'] = Octicon("triangle-right").nowrap().color("lightgray")
+            self.children['____right__'] = Octicon(
+                "triangle-right").nowrap().color("lightgray")
         else:
             self.children['____right__'] = (
                 Clickable(
@@ -2054,7 +2111,8 @@ class Clickable(Cell):
             .replace('__onclick__', self.calculatedOnClick())
             .replace(
                 '__style__',
-                self._divStyle("cursor:pointer;*cursor: hand" + (";font-weight:bold" if self.bold else ""))
+                self._divStyle("cursor:pointer;*cursor: hand" +
+                               (";font-weight:bold" if self.bold else ""))
             )
         )
 
@@ -2064,7 +2122,8 @@ class Clickable(Cell):
     def onMessage(self, msgFrame):
         val = self.f()
         if isinstance(val, str):
-            self.triggerPostscript(quoteForJs("window.location.href = '__url__'".replace("__url__", quoteForJs(val, "'")), '"'))
+            self.triggerPostscript(quoteForJs("window.location.href = '__url__'".replace(
+                "__url__", quoteForJs(val, "'")), '"'))
 
 
 class Button(Clickable):
@@ -2097,7 +2156,8 @@ class ButtonGroup(Cell):
         self.buttons = buttons
 
     def recalculate(self):
-        self.children = {f'____{i}__': self.buttons[i] for i in range(len(self.buttons))}
+        self.children = {
+            f'____{i}__': self.buttons[i] for i in range(len(self.buttons))}
         self.contents = (
             """
             <div class="btn-group" role="group">
@@ -2223,7 +2283,8 @@ class CodeEditor(Cell):
             and a json selection.
         """
         super().__init__()
-        self._slot = Slot((0, ""))  # contains (current_iteration_number: int, text: str)
+        # contains (current_iteration_number: int, text: str)
+        self._slot = Slot((0, ""))
         self.keybindings = keybindings or {}
         self.noScroll = noScroll
         self.fontSize = fontSize
@@ -2236,16 +2297,19 @@ class CodeEditor(Cell):
         return self._slot.get()[1]
 
     def setContents(self, contents):
-        newSlotState = (self._slot.getWithoutRegisteringDependency()[0]+1000000, contents)
+        newSlotState = (self._slot.getWithoutRegisteringDependency()[
+                        0]+1000000, contents)
         self._slot.set(newSlotState)
         self.sendCurrentStateToBrowser(newSlotState)
 
     def onMessage(self, msgFrame):
         if msgFrame['event'] == 'keybinding':
-            self.keybindings[msgFrame['key']](msgFrame['buffer'], msgFrame['selection'])
+            self.keybindings[msgFrame['key']](
+                msgFrame['buffer'], msgFrame['selection'])
         elif msgFrame['event'] == 'editing':
             if self.onTextChange:
-                self._slot.set((self._slot.getWithoutRegisteringDependency()[0] + 1, msgFrame['buffer']))
+                self._slot.set((self._slot.getWithoutRegisteringDependency()[
+                               0] + 1, msgFrame['buffer']))
                 self.onTextChange(msgFrame['buffer'], msgFrame['selection'])
 
     def recalculate(self):
@@ -2346,7 +2410,8 @@ class CodeEditor(Cell):
             });
             """.replace("__key__", kb)
 
-        self.postscript = self.postscript.replace("__identity__", self.identity)
+        self.postscript = self.postscript.replace(
+            "__identity__", self.identity)
 
     def sendCurrentStateToBrowser(self, newSlotState):
         if self.cells is not None:
@@ -2406,7 +2471,8 @@ class Sheet(Cell):
 
         self.columnNames = columnNames
         self.rowCount = rowCount
-        self.rowFun = rowFun  # for a row, the value of all the columns in a list.
+        # for a row, the value of all the columns in a list.
+        self.rowFun = rowFun
         self.colWidth = colWidth
         self.error = Slot(None)
         self._overflow = "auto"
@@ -2421,7 +2487,8 @@ class Sheet(Cell):
                                           col=msgFrame["col"])
                 return _onMessage
 
-            self._hookfns["onCellDblClick"] = _makeOnCellDblClick(onCellDblClick)
+            self._hookfns["onCellDblClick"] = _makeOnCellDblClick(
+                onCellDblClick)
 
     def _addHandsontableOnCellDblClick(self):
         return """
@@ -2567,7 +2634,8 @@ class Sheet(Cell):
                         dblClicked: true
                 }
                 """ +
-                (self._addHandsontableOnCellDblClick() if "onCellDblClick" in self._hookfns else "")
+                (self._addHandsontableOnCellDblClick()
+                 if "onCellDblClick" in self._hookfns else "")
             )
             .replace("__identity__", self._identity)
             .replace("__rows__", str(self.rowCount))
@@ -2686,7 +2754,8 @@ class Plot(Cell):
              (d.get('yaxis.range[0]', curVal[1][0]), d.get('yaxis.range[1]', curVal[1][1])))
         )
 
-        self.cells._logger.info("User navigated plot to %s", self.curXYRanges.get())
+        self.cells._logger.info(
+            "User navigated plot to %s", self.curXYRanges.get())
 
     def setXRange(self, low, high):
         curXY = self.curXYRanges.getWithoutRegisteringDependency()
@@ -2762,7 +2831,8 @@ class _PlotUpdater(Cell):
         data = self.callFun(callableOrData)
 
         if isinstance(data, list):
-            res = {'x': [float(x) for x in range(len(data))], 'y': [float(d) for d in data]}
+            res = {'x': [float(x) for x in range(len(data))],
+                   'y': [float(d) for d in data]}
         else:
             assert isinstance(data, dict)
             res = dict(data)

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -36,7 +36,7 @@ class HTMLElement(AbstractHTMLWriter):
             self.children.append(child_element)
             child_element.parent = self
 
-    def add_children(list_of_children):
+    def add_children(self, list_of_children):
         self.children = self.children + list_of_children
 
     def add_class(self, cls_string):
@@ -93,6 +93,8 @@ class HTMLElement(AbstractHTMLWriter):
                     ' {}="{}"'.format(key, val))
 
     def _print_children_on(self, io_stream, indent=0, indent_increment=4):
+        if len(self.children) == 0:
+            return
         indent += indent_increment
         for child in self.children:
             if isinstance(child, HTMLElement):

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -182,7 +182,7 @@ HTML_TAG_CONFIG = [
     {"tag_name": "data"},
     {"tag_name": "datalist"},
     {"tag_name": "dd"},
-    #{"tag_name": "del"}, # Invalid: conflicts with py somehow
+    {"tag_name": "_del"}, # decided not to overload the "del" destructor
     {"tag_name": "details"},
     {"tag_name": "dfn"},
     {"tag_name": "dialog"},

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -146,7 +146,7 @@ def _get_method_names(cls):
     return [item[0] for item in
             inspect.getmembers(cls, predicate=inspect.ismethod)]
 
-setattr(HTMLElement, "list_methods",
+setattr(HTMLElement, "all_methods",
         staticmethod(_get_method_names(HTMLElement)))
 
 

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -29,7 +29,7 @@ class HTMLElement(AbstractHTMLWriter):
         self.tag_name = tag_name
         self.is_self_closing = is_self_closing
         self.attributes = attributes if attributes is not None else {}
-        self.children = children 
+        self.children = children
         self.parent = None
 
     def add_child(self, child_element):
@@ -131,20 +131,138 @@ def _func(cls, *args, **kwargs):
     """Helper function for setting classmethods."""
     return cls(*args, **kwargs)
 
+
 HTML_TAG_CONFIG = [
+    {"tag_name": "a"},
+    {"tag_name": "abbr"},
+    {"tag_name": "address"},
+    {"is_self_closing": True, "tag_name": "area"},
+    {"tag_name": "article"},
+    {"tag_name": "aside"},
+    {"tag_name": "audio"},
+    {"tag_name": "b"},
+    {"is_self_closing": True, "tag_name": "base"},
+    {"tag_name": "bdi"},
+    {"tag_name": "bdo"},
+    {"tag_name": "blockquote"},
+    {"tag_name": "body"},
+    {"is_self_closing": True, "tag_name": "br"},
+    {"tag_name": "button"},
+    {"tag_name": "canvas"},
+    {"tag_name": "caption"},
+    {"tag_name": "cite"},
+    {"tag_name": "code"},
+    {"is_self_closing": True, "tag_name": "col"},
+    {"tag_name": "colgroup"},
+    {"tag_name": "data"},
+    {"tag_name": "datalist"},
+    {"tag_name": "dd"},
+    {"tag_name": "del"},
+    {"tag_name": "details"},
+    {"tag_name": "dfn"},
+    {"tag_name": "dialog"},
     {"tag_name": "div"},
+    {"tag_name": "dl"},
+    {"tag_name": "dt"},
+    {"tag_name": "em"},
+    {"is_self_closing": True, "tag_name": "embed"},
+    {"tag_name": "fieldset"},
+    {"tag_name": "figcaption"},
+    {"tag_name": "figure"},
+    {"tag_name": "footer"},
+    {"tag_name": "form"},
+    {"tag_name": "h1"},
+    {"tag_name": "h2"},
+    {"tag_name": "h3"},
+    {"tag_name": "h4"},
+    {"tag_name": "h5"},
+    {"tag_name": "h6"},
+    {"tag_name": "head"},
+    {"tag_name": "header"},
+    {"tag_name": "hgroup"},
+    {"is_self_closing": True, "tag_name": "hr"},
+    {"tag_name": "html"},
+    {"tag_name": "i"},
+    {"tag_name": "iframe"},
+    {"is_self_closing": True, "tag_name": "img"},
+    {"is_self_closing": True, "tag_name": "input"},
+    {"tag_name": "ins"},
+    {"tag_name": "kbd"},
+    {"tag_name": "keygen"},
+    {"tag_name": "label"},
+    {"tag_name": "legend"},
+    {"tag_name": "li"},
+    {"is_self_closing": True, "tag_name": "link"},
+    {"tag_name": "main"},
+    {"tag_name": "map"},
+    {"tag_name": "mark"},
+    {"tag_name": "math"},
+    {"tag_name": "menu"},
+    {"tag_name": "menuitem"},
+    {"is_self_closing": True, "tag_name": "meta"},
+    {"tag_name": "meter"},
+    {"tag_name": "nav"},
+    {"tag_name": "noscript"},
+    {"tag_name": "object"},
+    {"tag_name": "ol"},
+    {"tag_name": "optgroup"},
+    {"tag_name": "option"},
+    {"tag_name": "output"},
     {"tag_name": "p"},
-    {"tag_name": "img", "is_self_closing": True},
-]
+    {"is_self_closing": True, "tag_name": "param"},
+    {"tag_name": "picture"},
+    {"tag_name": "pre"},
+    {"tag_name": "progress"},
+    {"tag_name": "q"},
+    {"tag_name": "rb"},
+    {"tag_name": "rp"},
+    {"tag_name": "rt"},
+    {"tag_name": "rtc"},
+    {"tag_name": "ruby"},
+    {"tag_name": "s"},
+    {"tag_name": "samp"},
+    {"tag_name": "script"},
+    {"tag_name": "section"},
+    {"tag_name": "select"},
+    {"tag_name": "slot"},
+    {"tag_name": "small"},
+    {"is_self_closing": True, "tag_name": "source"},
+    {"tag_name": "span"},
+    {"tag_name": "strong"},
+    {"tag_name": "style"},
+    {"tag_name": "sub"},
+    {"tag_name": "summary"},
+    {"tag_name": "sup"},
+    {"tag_name": "svg"},
+    {"tag_name": "table"},
+    {"tag_name": "tbody"},
+    {"tag_name": "td"},
+    {"tag_name": "template"},
+    {"tag_name": "textarea"},
+    {"tag_name": "tfoot"},
+    {"tag_name": "th"},
+    {"tag_name": "thead"},
+    {"tag_name": "time"},
+    {"tag_name": "title"},
+    {"tag_name": "tr"},
+    {"is_self_closing": True, "tag_name": "track"},
+    {"tag_name": "u"},
+    {"tag_name": "ul"},
+    {"tag_name": "var"},
+    {"tag_name": "video"},
+    {"is_self_closing": True, "tag_name": "wbr"}]
 
 for tag in HTML_TAG_CONFIG:
     setattr(HTMLElement, tag["tag_name"],
             classmethod(partial(_func, **tag)))
 
 # helper static method for inspecting all available tags
+
+
 def _get_method_names(cls):
     return [item[0] for item in
             inspect.getmembers(cls, predicate=inspect.ismethod)]
+
 
 setattr(HTMLElement, "all_methods",
         staticmethod(_get_method_names(HTMLElement)))

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -230,10 +230,12 @@ class HTMLElement(AbstractHTMLWriter):
             that can be used for chaining.
         """
         if 'class' in self.attributes:
-            current = self.attributes['class'].split()
-            current_set = set(current)
-            current_set.add(cls_string)
-            self.attributes['class'] = " ".join(list(current_set))
+            class_list = self.attributes['class'].split()
+            if cls_string not in class_list:
+                class_list.append(cls_string)
+                self.attributes['class'] = " ".join(class_list)
+        else:
+            self.attributes["class"] = cls_string
         return self
 
     def remove_class(self, cls_string):
@@ -262,12 +264,37 @@ class HTMLElement(AbstractHTMLWriter):
             that can be used for chaining.
         """
         if 'class' in self.attributes:
-            current = self.attributes['class'].split()
-            current_set = set(current)
-            if cls_string not in current_set:
-                return self
-            current_set.remove(cls_string)
-            self.attributes['class'] = " ".join(list(current_set))
+            class_list = self.attributes["class"].split()
+            if cls_string in class_list:
+                class_list.remove(cls_string)
+            self.attributes['class'] = " ".join(class_list)
+        return self
+
+    def add_classes(self, list_of_str):
+        """Adds HTML element class values from a list
+
+        Example
+        -------
+        Add three classes from a list::
+            classes_to_add = ["one", "two", "three"]
+            element = HTMLElement()
+            element.add_classes(classes_to_add)
+            print(element.attributes["class"])
+            # 'one two three'
+
+        Parameters
+        ----------
+        list_of_str: list
+            A list of strings that are HTML class values
+
+        Returns
+        -------
+        HTMLElement
+            A reference to the current instance that can be
+            used for chaining calls.
+        """
+        for class_str in list_of_str:
+            self.add_class(class_str)
         return self
 
     def pretty_print(self, indent_increment=2):

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -157,7 +157,7 @@ HTML_TAG_CONFIG = [
     {"tag_name": "data"},
     {"tag_name": "datalist"},
     {"tag_name": "dd"},
-    {"tag_name": "del"},
+    #{"tag_name": "del"}, # Invalid: conflicts with py somehow
     {"tag_name": "details"},
     {"tag_name": "dfn"},
     {"tag_name": "dialog"},

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -540,6 +540,7 @@ class HTMLTextContent(AbstractHTMLWriter):
         """
         super().__init__()
         self.content = content
+        self.parent = None
 
     def print_on(self, io_stream, indent=0, indent_increment=4, newlines=True):
         """Print the text content to a given stream

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -21,11 +21,12 @@ class AbstractHTMLWriter(ABC):
 
 
 class HTMLElement(AbstractHTMLWriter):
-    def __init__(self, tag_name=None, attributes={}, children=[], is_self_closing=False):
+    def __init__(self, tag_name=None, attributes=None, children=None,
+                 is_self_closing=False):
         self.tag_name = tag_name
         self.is_self_closing = is_self_closing
-        self.attributes = attributes
-        self.children = children
+        self.attributes = attributes if attributes is not None else {}
+        self.children = children 
         self.parent = None
 
     def add_child(self, child_element):
@@ -34,12 +35,16 @@ class HTMLElement(AbstractHTMLWriter):
                 '{} elements do not have children'.format(self.tag_name))
         elif child_element.parent:
             child_element.parent.remove_child(child_element)
-        self.children.append(child_element)
+        if self.children is None:
+            self.children = [child_element]
+        else:
+            self.children.append(child_element)
         child_element.parent = self
 
     def remove_child(self, child_element):
-        if child_element not in self.children:
-            return
+        if self.children is None or child_element not in self.children:
+            raise HTMLElementChildrenError(
+                '{} elements does not have children'.format(self.tag_name))
         self.children = [kid for kid in self.children if kid != child_element]
 
     def add_children(self, list_of_children):
@@ -105,7 +110,7 @@ class HTMLElement(AbstractHTMLWriter):
                     ' {}="{}"'.format(key, val))
 
     def _print_children_on(self, io_stream, indent=0, indent_increment=4):
-        if len(self.children) == 0:
+        if self.children is None or len(self.children) == 0:
             return
         indent += indent_increment
         for child in self.children:

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -58,16 +58,19 @@ class HTMLElement(AbstractHTMLWriter):
         else:
             self.children.append(child_element)
         child_element.parent = self
+        return self
 
     def remove_child(self, child_element):
         if self.children is None or child_element not in self.children:
             raise HTMLElementChildrenError(
                 '{} elements does not have children'.format(self.tag_name))
         self.children = [kid for kid in self.children if kid != child_element]
+        return self
 
     def add_children(self, list_of_children):
         for child in list_of_children:
             self.add_child(child)
+        return self
 
     def add_class(self, cls_string):
         if 'class' in self.attributes:
@@ -75,15 +78,21 @@ class HTMLElement(AbstractHTMLWriter):
             current_set = set(current)
             current_set.add(cls_string)
             self.attributes['class'] = " ".join(list(current_set))
+        return self
 
     def remove_class(self, cls_string):
         if 'class' in self.attributes:
             current = self.attributes['class'].split()
             current_set = set(current)
             if cls_string not in current_set:
-                return
+                return self
             current_set.remove(cls_string)
             self.attributes['class'] = " ".join(list(current_set))
+        return self
+
+    def with_children(self, *args):
+        self.add_children(args)
+        return self
 
     def __str__(self):
         stream = StringIO()

--- a/object_database/web/html/html_gen.py
+++ b/object_database/web/html/html_gen.py
@@ -24,8 +24,23 @@ class AbstractHTMLWriter(ABC):
 
 
 class HTMLElement(AbstractHTMLWriter):
+    """HTML element generation class."""
     def __init__(self, tag_name=None, attributes=None, children=None,
                  is_self_closing=False):
+        """
+        Parameters:
+        ----------
+        tag_name: str
+            example: div, p, a etc
+        attributes : dict
+            html tag attributes
+        children : list
+            list of HTMLElement or HTMLTextContent
+        is_self_closing : bool
+            a self-closing tag does not carry a content payload;
+            example: <img src="path to img"/>
+
+        """
         self.tag_name = tag_name
         self.is_self_closing = is_self_closing
         self.attributes = attributes if attributes is not None else {}
@@ -84,6 +99,16 @@ class HTMLElement(AbstractHTMLWriter):
         return stream.getvalue()
 
     def print_on(self, io_stream, indent=0, indent_increment=4, newlines=True):
+        """Print payload to stream.
+
+        Parameters:
+        ----------
+        io_stream: Stream
+        indent: int
+        indent_increment: int
+        newlines: True
+            print with newlines
+        """
         self._print_open_tag_on(io_stream, indent, newlines)
         if not self.is_self_closing:
             self._print_children_on(io_stream, indent, indent_increment)
@@ -269,11 +294,30 @@ setattr(HTMLElement, "all_methods",
 
 
 class HTMLTextContent(AbstractHTMLWriter):
+    """Display raw content in a div."""
     def __init__(self, content):
+        """
+        Parameters:
+        ----------
+        content: str
+        """
         super().__init__()
         self.content = content
 
     def print_on(self, io_stream, indent=0, indent_increment=4, newlines=True):
-        for line in self.content.split("\n"):
+        """Print payload to stream.
+
+        Parameters:
+        ----------
+        io_stream: Stream
+        indent: int
+        indent_increment: int
+        newlines: True
+            print with newlines
+        """
+        for line in self.content.splitlines():
             inline_indent = " " * indent
-            io_stream.write('{}{}\n'.format(inline_indent, line))
+            if newlines:
+                io_stream.write('{}{}\n'.format(inline_indent, line))
+            else:
+                io_stream.write('{}{} '.format(inline_indent, line))

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -1,0 +1,45 @@
+from html_gen import *
+from io import StringIO
+
+import unittest
+
+class HTMLGeneratorTests(unittest.TestCase):
+    def test_add_child(self):
+        test_child = HTMLElement()
+        test_parent = HTMLElement()
+        test_parent.add_child(test_child)
+        self.assertTrue(test_child in test_parent.children)
+
+    def test_add_child_self_closing(self):
+        test_child = HTMLElement()
+        test_parent = HTMLElement(is_self_closing=True)
+        self.assertRaises(HTMLElementChildrenError, test_parent.add_child, test_child)
+
+    def test_add_children(self):
+        kids = [HTMLElement() for i in range(0, 10)]
+        test_parent = HTMLElement()
+        test_parent.add_children(kids)
+        all_present = True
+        for kid in kids:
+            if kid not in test_parent.children:
+                all_present = False
+        self.assertTrue(all_present)
+
+    def test_print_on(self):
+        stream = StringIO()
+        element = HTMLElement('div')
+        element.attributes['class'] = 'column-4 medium'
+        output = element.__str__()
+        self.assertEquals('<div class="column-4 medium"></div>', output)
+    """
+    def test_print_on_with_child(self):
+        stream = StringIO()
+        element = HTMLElement('div', {'class': "column-4 medium"})
+        child = HTMLElement('img', is_self_closing=True)
+        element.add_child(child)
+        expected = '''<div class="column-4 medium">\n    <img/>\n</div>'''
+        print("Running print_on...")
+        element.print_on(stream)
+        print("Printing output")
+        output = stream.getvalue()
+        self.assertEquals(expected, output)"""

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -29,17 +29,6 @@ class HTMLGeneratorTests(unittest.TestCase):
         stream = StringIO()
         element = HTMLElement('div')
         element.attributes['class'] = 'column-4 medium'
-        output = element.__str__()
-        self.assertEquals('<div class="column-4 medium"></div>', output)
-    """
-    def test_print_on_with_child(self):
-        stream = StringIO()
-        element = HTMLElement('div', {'class': "column-4 medium"})
-        child = HTMLElement('img', is_self_closing=True)
-        element.add_child(child)
-        expected = '''<div class="column-4 medium">\n    <img/>\n</div>'''
-        print("Running print_on...")
-        element.print_on(stream)
-        print("Printing output")
+        element.print_on(stream, newlines=False)
         output = stream.getvalue()
-        self.assertEquals(expected, output)"""
+        self.assertEquals('<div class="column-4 medium"></div>', output)

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -3,7 +3,12 @@
 import re
 import unittest
 
-from html_gen import HTMLElement, HTML_TAG_CONFIG, HTMLElementChildrenError
+from html_gen import (
+    HTMLElement,
+    HTMLTextContent,
+    HTML_TAG_CONFIG,
+    HTMLElementChildrenError
+)
 from io import StringIO
 
 
@@ -52,6 +57,28 @@ class HTMLGeneratorTests(unittest.TestCase):
         output = stream.getvalue()
         test_out = ('<div class="column-4 medium"><p class="column-4 medium">' +
                     '</p></div>')
+        # we don't care about white spaces or new linesso much
+        output = re.sub('\s{2,}', '', output)
+        output = re.sub(r'\n', '', output)
+        self.assertEqual(test_out, output)
+
+    def test_print_on_with_content(self):
+        stream = StringIO()
+        element = HTMLTextContent('this is content')
+        element.print_on(stream)
+        output = stream.getvalue()
+        test_out = "this is content\n" 
+        self.assertEqual(test_out, output)
+
+    def test_print_on_with_content_nested(self):
+        stream = StringIO()
+        content = HTMLTextContent('this is content')
+        parent = HTMLElement('div', children=[content])
+        parent.attributes['class'] = 'column-4 medium'
+        parent.print_on(stream, newlines=False)
+        output = stream.getvalue()
+        test_out = ('<div class="column-4 medium">this is content' +
+                    '</div>')
         # we don't care about white spaces or new linesso much
         output = re.sub('\s{2,}', '', output)
         output = re.sub(r'\n', '', output)

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -1,9 +1,14 @@
+#!/usr/bin/env python3
+
 from html_gen import *
 from io import StringIO
 
 import unittest
 
 class HTMLGeneratorTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
     def test_add_child(self):
         test_child = HTMLElement()
         test_parent = HTMLElement()
@@ -31,4 +36,11 @@ class HTMLGeneratorTests(unittest.TestCase):
         element.attributes['class'] = 'column-4 medium'
         element.print_on(stream, newlines=False)
         output = stream.getvalue()
-        self.assertEquals('<div class="column-4 medium"></div>', output)
+        self.assertEqual('<div class="column-4 medium"></div>', output)
+
+    def tearDown(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -92,6 +92,14 @@ class HTMLGeneratorTests(unittest.TestCase):
         output = stream.getvalue()
         self.assertEqual('<div class="column-4 medium"></div>', output)
 
+    def test_with_children(self):
+        element = HTMLElement('div')
+        child_one = HTMLElement('img')
+        child_two = HTMLElement('article')
+        element.with_children(child_one, child_two)
+        self.assertTrue(child_one in element.children)
+        self.assertTrue(child_two in element.children)
+
     def test_list_methods(self):
         method_names = HTMLElement.all_methods
         for name in self.current_tag_names:
@@ -100,6 +108,37 @@ class HTMLGeneratorTests(unittest.TestCase):
     def tearDown(self):
         pass
 
+class HTMLChainingMethodTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_chaining_add_child(self):
+        element = HTMLElement('div')
+        result = element.add_child(HTMLElement())
+        self.assertEqual(element, result)
+
+    def test_chaining_remove_child(self):
+        element = HTMLElement()
+        child = HTMLElement()
+        element.add_child(child)
+        result = element.remove_child(child)
+        self.assertEqual(element, result)
+
+    def test_chaining_add_children(self):
+        element = HTMLElement('div')
+        children = [HTMLElement(), HTMLElement()]
+        result = element.add_children(children)
+        self.assertEqual(element, result)
+
+    def test_chaining_with_children(self):
+        element = HTMLElement('div')
+        child_one = HTMLElement()
+        child_two = HTMLElement()
+        result = element.with_children(child_one, child_two)
+        self.assertEqual(result, element)
+
+    def tearDown(self):
+        pass
 
 class HTMLCustomConstructorTests(unittest.TestCase):
     def setUp(self):

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -225,6 +225,11 @@ class HTMLCustomConstructorTests(unittest.TestCase):
         self.assertEqual(element.tag_name, 'dd')
         self.assertFalse(element.is_self_closing)
 
+    def test_del_constructor(self):
+        element = HTMLElement._del()
+        self.assertEqual(element.tag_name, '_del')
+        self.assertFalse(element.is_self_closing)
+
     def test_details_constructor(self):
         element = HTMLElement.details()
         self.assertEqual(element.tag_name, 'details')

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -50,8 +50,8 @@ class HTMLGeneratorTests(unittest.TestCase):
         parent.attributes['class'] = 'column-4 medium'
         parent.print_on(stream, newlines=False)
         output = stream.getvalue()
-        test_out =('<div class="column-4 medium"><p class="column-4 medium">' +
-                  '</p></div>')
+        test_out = ('<div class="column-4 medium"><p class="column-4 medium">' +
+                    '</p></div>')
         # we don't care about white spaces or new linesso much
         output = re.sub('\s{2,}', '', output)
         output = re.sub(r'\n', '', output)
@@ -69,6 +69,599 @@ class HTMLGeneratorTests(unittest.TestCase):
         method_names = HTMLElement.all_methods
         for name in self.current_tag_names:
             self.assertIn(name, method_names)
+
+    def tearDown(self):
+        pass
+
+
+class HTMLCustomConstructorTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_a_constructor(self):
+        element = HTMLElement.a()
+        self.assertEqual(element.tag_name, 'a')
+        self.assertFalse(element.is_self_closing)
+
+    def test_abbr_constructor(self):
+        element = HTMLElement.abbr()
+        self.assertEqual(element.tag_name, 'abbr')
+        self.assertFalse(element.is_self_closing)
+
+    def test_address_constructor(self):
+        element = HTMLElement.address()
+        self.assertEqual(element.tag_name, 'address')
+        self.assertFalse(element.is_self_closing)
+
+    def test_area_constructor(self):
+        element = HTMLElement.area()
+        self.assertEqual(element.tag_name, 'area')
+        self.assertTrue(element.is_self_closing)
+
+    def test_article_constructor(self):
+        element = HTMLElement.article()
+        self.assertEqual(element.tag_name, 'article')
+        self.assertFalse(element.is_self_closing)
+
+    def test_aside_constructor(self):
+        element = HTMLElement.aside()
+        self.assertEqual(element.tag_name, 'aside')
+        self.assertFalse(element.is_self_closing)
+
+    def test_audio_constructor(self):
+        element = HTMLElement.audio()
+        self.assertEqual(element.tag_name, 'audio')
+        self.assertFalse(element.is_self_closing)
+
+    def test_b_constructor(self):
+        element = HTMLElement.b()
+        self.assertEqual(element.tag_name, 'b')
+        self.assertFalse(element.is_self_closing)
+
+    def test_base_constructor(self):
+        element = HTMLElement.base()
+        self.assertEqual(element.tag_name, 'base')
+        self.assertTrue(element.is_self_closing)
+
+    def test_bdi_constructor(self):
+        element = HTMLElement.bdi()
+        self.assertEqual(element.tag_name, 'bdi')
+        self.assertFalse(element.is_self_closing)
+
+    def test_bdo_constructor(self):
+        element = HTMLElement.bdo()
+        self.assertEqual(element.tag_name, 'bdo')
+        self.assertFalse(element.is_self_closing)
+
+    def test_blockquote_constructor(self):
+        element = HTMLElement.blockquote()
+        self.assertEqual(element.tag_name, 'blockquote')
+        self.assertFalse(element.is_self_closing)
+
+    def test_body_constructor(self):
+        element = HTMLElement.body()
+        self.assertEqual(element.tag_name, 'body')
+        self.assertFalse(element.is_self_closing)
+
+    def test_br_constructor(self):
+        element = HTMLElement.br()
+        self.assertEqual(element.tag_name, 'br')
+        self.assertTrue(element.is_self_closing)
+
+    def test_button_constructor(self):
+        element = HTMLElement.button()
+        self.assertEqual(element.tag_name, 'button')
+        self.assertFalse(element.is_self_closing)
+
+    def test_canvas_constructor(self):
+        element = HTMLElement.canvas()
+        self.assertEqual(element.tag_name, 'canvas')
+        self.assertFalse(element.is_self_closing)
+
+    def test_caption_constructor(self):
+        element = HTMLElement.caption()
+        self.assertEqual(element.tag_name, 'caption')
+        self.assertFalse(element.is_self_closing)
+
+    def test_cite_constructor(self):
+        element = HTMLElement.cite()
+        self.assertEqual(element.tag_name, 'cite')
+        self.assertFalse(element.is_self_closing)
+
+    def test_code_constructor(self):
+        element = HTMLElement.code()
+        self.assertEqual(element.tag_name, 'code')
+        self.assertFalse(element.is_self_closing)
+
+    def test_col_constructor(self):
+        element = HTMLElement.col()
+        self.assertEqual(element.tag_name, 'col')
+        self.assertTrue(element.is_self_closing)
+
+    def test_colgroup_constructor(self):
+        element = HTMLElement.colgroup()
+        self.assertEqual(element.tag_name, 'colgroup')
+        self.assertFalse(element.is_self_closing)
+
+    def test_data_constructor(self):
+        element = HTMLElement.data()
+        self.assertEqual(element.tag_name, 'data')
+        self.assertFalse(element.is_self_closing)
+
+    def test_datalist_constructor(self):
+        element = HTMLElement.datalist()
+        self.assertEqual(element.tag_name, 'datalist')
+        self.assertFalse(element.is_self_closing)
+
+    def test_dd_constructor(self):
+        element = HTMLElement.dd()
+        self.assertEqual(element.tag_name, 'dd')
+        self.assertFalse(element.is_self_closing)
+
+    def test_details_constructor(self):
+        element = HTMLElement.details()
+        self.assertEqual(element.tag_name, 'details')
+        self.assertFalse(element.is_self_closing)
+
+    def test_dfn_constructor(self):
+        element = HTMLElement.dfn()
+        self.assertEqual(element.tag_name, 'dfn')
+        self.assertFalse(element.is_self_closing)
+
+    def test_dialog_constructor(self):
+        element = HTMLElement.dialog()
+        self.assertEqual(element.tag_name, 'dialog')
+        self.assertFalse(element.is_self_closing)
+
+    def test_div_constructor(self):
+        element = HTMLElement.div()
+        self.assertEqual(element.tag_name, 'div')
+        self.assertFalse(element.is_self_closing)
+
+    def test_dl_constructor(self):
+        element = HTMLElement.dl()
+        self.assertEqual(element.tag_name, 'dl')
+        self.assertFalse(element.is_self_closing)
+
+    def test_dt_constructor(self):
+        element = HTMLElement.dt()
+        self.assertEqual(element.tag_name, 'dt')
+        self.assertFalse(element.is_self_closing)
+
+    def test_em_constructor(self):
+        element = HTMLElement.em()
+        self.assertEqual(element.tag_name, 'em')
+        self.assertFalse(element.is_self_closing)
+
+    def test_embed_constructor(self):
+        element = HTMLElement.embed()
+        self.assertEqual(element.tag_name, 'embed')
+        self.assertTrue(element.is_self_closing)
+
+    def test_fieldset_constructor(self):
+        element = HTMLElement.fieldset()
+        self.assertEqual(element.tag_name, 'fieldset')
+        self.assertFalse(element.is_self_closing)
+
+    def test_figcaption_constructor(self):
+        element = HTMLElement.figcaption()
+        self.assertEqual(element.tag_name, 'figcaption')
+        self.assertFalse(element.is_self_closing)
+
+    def test_figure_constructor(self):
+        element = HTMLElement.figure()
+        self.assertEqual(element.tag_name, 'figure')
+        self.assertFalse(element.is_self_closing)
+
+    def test_footer_constructor(self):
+        element = HTMLElement.footer()
+        self.assertEqual(element.tag_name, 'footer')
+        self.assertFalse(element.is_self_closing)
+
+    def test_form_constructor(self):
+        element = HTMLElement.form()
+        self.assertEqual(element.tag_name, 'form')
+        self.assertFalse(element.is_self_closing)
+
+    def test_h1_constructor(self):
+        element = HTMLElement.h1()
+        self.assertEqual(element.tag_name, 'h1')
+        self.assertFalse(element.is_self_closing)
+
+    def test_h2_constructor(self):
+        element = HTMLElement.h2()
+        self.assertEqual(element.tag_name, 'h2')
+        self.assertFalse(element.is_self_closing)
+
+    def test_h3_constructor(self):
+        element = HTMLElement.h3()
+        self.assertEqual(element.tag_name, 'h3')
+        self.assertFalse(element.is_self_closing)
+
+    def test_h4_constructor(self):
+        element = HTMLElement.h4()
+        self.assertEqual(element.tag_name, 'h4')
+        self.assertFalse(element.is_self_closing)
+
+    def test_h5_constructor(self):
+        element = HTMLElement.h5()
+        self.assertEqual(element.tag_name, 'h5')
+        self.assertFalse(element.is_self_closing)
+
+    def test_h6_constructor(self):
+        element = HTMLElement.h6()
+        self.assertEqual(element.tag_name, 'h6')
+        self.assertFalse(element.is_self_closing)
+
+    def test_head_constructor(self):
+        element = HTMLElement.head()
+        self.assertEqual(element.tag_name, 'head')
+        self.assertFalse(element.is_self_closing)
+
+    def test_header_constructor(self):
+        element = HTMLElement.header()
+        self.assertEqual(element.tag_name, 'header')
+        self.assertFalse(element.is_self_closing)
+
+    def test_hgroup_constructor(self):
+        element = HTMLElement.hgroup()
+        self.assertEqual(element.tag_name, 'hgroup')
+        self.assertFalse(element.is_self_closing)
+
+    def test_hr_constructor(self):
+        element = HTMLElement.hr()
+        self.assertEqual(element.tag_name, 'hr')
+        self.assertTrue(element.is_self_closing)
+
+    def test_html_constructor(self):
+        element = HTMLElement.html()
+        self.assertEqual(element.tag_name, 'html')
+        self.assertFalse(element.is_self_closing)
+
+    def test_i_constructor(self):
+        element = HTMLElement.i()
+        self.assertEqual(element.tag_name, 'i')
+        self.assertFalse(element.is_self_closing)
+
+    def test_iframe_constructor(self):
+        element = HTMLElement.iframe()
+        self.assertEqual(element.tag_name, 'iframe')
+        self.assertFalse(element.is_self_closing)
+
+    def test_img_constructor(self):
+        element = HTMLElement.img()
+        self.assertEqual(element.tag_name, 'img')
+        self.assertTrue(element.is_self_closing)
+
+    def test_input_constructor(self):
+        element = HTMLElement.input()
+        self.assertEqual(element.tag_name, 'input')
+        self.assertTrue(element.is_self_closing)
+
+    def test_ins_constructor(self):
+        element = HTMLElement.ins()
+        self.assertEqual(element.tag_name, 'ins')
+        self.assertFalse(element.is_self_closing)
+
+    def test_kbd_constructor(self):
+        element = HTMLElement.kbd()
+        self.assertEqual(element.tag_name, 'kbd')
+        self.assertFalse(element.is_self_closing)
+
+    def test_keygen_constructor(self):
+        element = HTMLElement.keygen()
+        self.assertEqual(element.tag_name, 'keygen')
+        self.assertFalse(element.is_self_closing)
+
+    def test_label_constructor(self):
+        element = HTMLElement.label()
+        self.assertEqual(element.tag_name, 'label')
+        self.assertFalse(element.is_self_closing)
+
+    def test_legend_constructor(self):
+        element = HTMLElement.legend()
+        self.assertEqual(element.tag_name, 'legend')
+        self.assertFalse(element.is_self_closing)
+
+    def test_li_constructor(self):
+        element = HTMLElement.li()
+        self.assertEqual(element.tag_name, 'li')
+        self.assertFalse(element.is_self_closing)
+
+    def test_link_constructor(self):
+        element = HTMLElement.link()
+        self.assertEqual(element.tag_name, 'link')
+        self.assertTrue(element.is_self_closing)
+
+    def test_main_constructor(self):
+        element = HTMLElement.main()
+        self.assertEqual(element.tag_name, 'main')
+        self.assertFalse(element.is_self_closing)
+
+    def test_map_constructor(self):
+        element = HTMLElement.map()
+        self.assertEqual(element.tag_name, 'map')
+        self.assertFalse(element.is_self_closing)
+
+    def test_mark_constructor(self):
+        element = HTMLElement.mark()
+        self.assertEqual(element.tag_name, 'mark')
+        self.assertFalse(element.is_self_closing)
+
+    def test_math_constructor(self):
+        element = HTMLElement.math()
+        self.assertEqual(element.tag_name, 'math')
+        self.assertFalse(element.is_self_closing)
+
+    def test_menu_constructor(self):
+        element = HTMLElement.menu()
+        self.assertEqual(element.tag_name, 'menu')
+        self.assertFalse(element.is_self_closing)
+
+    def test_menuitem_constructor(self):
+        element = HTMLElement.menuitem()
+        self.assertEqual(element.tag_name, 'menuitem')
+        self.assertFalse(element.is_self_closing)
+
+    def test_meta_constructor(self):
+        element = HTMLElement.meta()
+        self.assertEqual(element.tag_name, 'meta')
+        self.assertTrue(element.is_self_closing)
+
+    def test_meter_constructor(self):
+        element = HTMLElement.meter()
+        self.assertEqual(element.tag_name, 'meter')
+        self.assertFalse(element.is_self_closing)
+
+    def test_nav_constructor(self):
+        element = HTMLElement.nav()
+        self.assertEqual(element.tag_name, 'nav')
+        self.assertFalse(element.is_self_closing)
+
+    def test_noscript_constructor(self):
+        element = HTMLElement.noscript()
+        self.assertEqual(element.tag_name, 'noscript')
+        self.assertFalse(element.is_self_closing)
+
+    def test_object_constructor(self):
+        element = HTMLElement.object()
+        self.assertEqual(element.tag_name, 'object')
+        self.assertFalse(element.is_self_closing)
+
+    def test_ol_constructor(self):
+        element = HTMLElement.ol()
+        self.assertEqual(element.tag_name, 'ol')
+        self.assertFalse(element.is_self_closing)
+
+    def test_optgroup_constructor(self):
+        element = HTMLElement.optgroup()
+        self.assertEqual(element.tag_name, 'optgroup')
+        self.assertFalse(element.is_self_closing)
+
+    def test_option_constructor(self):
+        element = HTMLElement.option()
+        self.assertEqual(element.tag_name, 'option')
+        self.assertFalse(element.is_self_closing)
+
+    def test_output_constructor(self):
+        element = HTMLElement.output()
+        self.assertEqual(element.tag_name, 'output')
+        self.assertFalse(element.is_self_closing)
+
+    def test_p_constructor(self):
+        element = HTMLElement.p()
+        self.assertEqual(element.tag_name, 'p')
+        self.assertFalse(element.is_self_closing)
+
+    def test_param_constructor(self):
+        element = HTMLElement.param()
+        self.assertEqual(element.tag_name, 'param')
+        self.assertTrue(element.is_self_closing)
+
+    def test_picture_constructor(self):
+        element = HTMLElement.picture()
+        self.assertEqual(element.tag_name, 'picture')
+        self.assertFalse(element.is_self_closing)
+
+    def test_pre_constructor(self):
+        element = HTMLElement.pre()
+        self.assertEqual(element.tag_name, 'pre')
+        self.assertFalse(element.is_self_closing)
+
+    def test_progress_constructor(self):
+        element = HTMLElement.progress()
+        self.assertEqual(element.tag_name, 'progress')
+        self.assertFalse(element.is_self_closing)
+
+    def test_q_constructor(self):
+        element = HTMLElement.q()
+        self.assertEqual(element.tag_name, 'q')
+        self.assertFalse(element.is_self_closing)
+
+    def test_rb_constructor(self):
+        element = HTMLElement.rb()
+        self.assertEqual(element.tag_name, 'rb')
+        self.assertFalse(element.is_self_closing)
+
+    def test_rp_constructor(self):
+        element = HTMLElement.rp()
+        self.assertEqual(element.tag_name, 'rp')
+        self.assertFalse(element.is_self_closing)
+
+    def test_rt_constructor(self):
+        element = HTMLElement.rt()
+        self.assertEqual(element.tag_name, 'rt')
+        self.assertFalse(element.is_self_closing)
+
+    def test_rtc_constructor(self):
+        element = HTMLElement.rtc()
+        self.assertEqual(element.tag_name, 'rtc')
+        self.assertFalse(element.is_self_closing)
+
+    def test_ruby_constructor(self):
+        element = HTMLElement.ruby()
+        self.assertEqual(element.tag_name, 'ruby')
+        self.assertFalse(element.is_self_closing)
+
+    def test_s_constructor(self):
+        element = HTMLElement.s()
+        self.assertEqual(element.tag_name, 's')
+        self.assertFalse(element.is_self_closing)
+
+    def test_samp_constructor(self):
+        element = HTMLElement.samp()
+        self.assertEqual(element.tag_name, 'samp')
+        self.assertFalse(element.is_self_closing)
+
+    def test_script_constructor(self):
+        element = HTMLElement.script()
+        self.assertEqual(element.tag_name, 'script')
+        self.assertFalse(element.is_self_closing)
+
+    def test_section_constructor(self):
+        element = HTMLElement.section()
+        self.assertEqual(element.tag_name, 'section')
+        self.assertFalse(element.is_self_closing)
+
+    def test_select_constructor(self):
+        element = HTMLElement.select()
+        self.assertEqual(element.tag_name, 'select')
+        self.assertFalse(element.is_self_closing)
+
+    def test_slot_constructor(self):
+        element = HTMLElement.slot()
+        self.assertEqual(element.tag_name, 'slot')
+        self.assertFalse(element.is_self_closing)
+
+    def test_small_constructor(self):
+        element = HTMLElement.small()
+        self.assertEqual(element.tag_name, 'small')
+        self.assertFalse(element.is_self_closing)
+
+    def test_source_constructor(self):
+        element = HTMLElement.source()
+        self.assertEqual(element.tag_name, 'source')
+        self.assertTrue(element.is_self_closing)
+
+    def test_span_constructor(self):
+        element = HTMLElement.span()
+        self.assertEqual(element.tag_name, 'span')
+        self.assertFalse(element.is_self_closing)
+
+    def test_strong_constructor(self):
+        element = HTMLElement.strong()
+        self.assertEqual(element.tag_name, 'strong')
+        self.assertFalse(element.is_self_closing)
+
+    def test_style_constructor(self):
+        element = HTMLElement.style()
+        self.assertEqual(element.tag_name, 'style')
+        self.assertFalse(element.is_self_closing)
+
+    def test_sub_constructor(self):
+        element = HTMLElement.sub()
+        self.assertEqual(element.tag_name, 'sub')
+        self.assertFalse(element.is_self_closing)
+
+    def test_summary_constructor(self):
+        element = HTMLElement.summary()
+        self.assertEqual(element.tag_name, 'summary')
+        self.assertFalse(element.is_self_closing)
+
+    def test_sup_constructor(self):
+        element = HTMLElement.sup()
+        self.assertEqual(element.tag_name, 'sup')
+        self.assertFalse(element.is_self_closing)
+
+    def test_svg_constructor(self):
+        element = HTMLElement.svg()
+        self.assertEqual(element.tag_name, 'svg')
+        self.assertFalse(element.is_self_closing)
+
+    def test_table_constructor(self):
+        element = HTMLElement.table()
+        self.assertEqual(element.tag_name, 'table')
+        self.assertFalse(element.is_self_closing)
+
+    def test_tbody_constructor(self):
+        element = HTMLElement.tbody()
+        self.assertEqual(element.tag_name, 'tbody')
+        self.assertFalse(element.is_self_closing)
+
+    def test_td_constructor(self):
+        element = HTMLElement.td()
+        self.assertEqual(element.tag_name, 'td')
+        self.assertFalse(element.is_self_closing)
+
+    def test_template_constructor(self):
+        element = HTMLElement.template()
+        self.assertEqual(element.tag_name, 'template')
+        self.assertFalse(element.is_self_closing)
+
+    def test_textarea_constructor(self):
+        element = HTMLElement.textarea()
+        self.assertEqual(element.tag_name, 'textarea')
+        self.assertFalse(element.is_self_closing)
+
+    def test_tfoot_constructor(self):
+        element = HTMLElement.tfoot()
+        self.assertEqual(element.tag_name, 'tfoot')
+        self.assertFalse(element.is_self_closing)
+
+    def test_th_constructor(self):
+        element = HTMLElement.th()
+        self.assertEqual(element.tag_name, 'th')
+        self.assertFalse(element.is_self_closing)
+
+    def test_thead_constructor(self):
+        element = HTMLElement.thead()
+        self.assertEqual(element.tag_name, 'thead')
+        self.assertFalse(element.is_self_closing)
+
+    def test_time_constructor(self):
+        element = HTMLElement.time()
+        self.assertEqual(element.tag_name, 'time')
+        self.assertFalse(element.is_self_closing)
+
+    def test_title_constructor(self):
+        element = HTMLElement.title()
+        self.assertEqual(element.tag_name, 'title')
+        self.assertFalse(element.is_self_closing)
+
+    def test_tr_constructor(self):
+        element = HTMLElement.tr()
+        self.assertEqual(element.tag_name, 'tr')
+        self.assertFalse(element.is_self_closing)
+
+    def test_track_constructor(self):
+        element = HTMLElement.track()
+        self.assertEqual(element.tag_name, 'track')
+        self.assertTrue(element.is_self_closing)
+
+    def test_u_constructor(self):
+        element = HTMLElement.u()
+        self.assertEqual(element.tag_name, 'u')
+        self.assertFalse(element.is_self_closing)
+
+    def test_ul_constructor(self):
+        element = HTMLElement.ul()
+        self.assertEqual(element.tag_name, 'ul')
+        self.assertFalse(element.is_self_closing)
+
+    def test_var_constructor(self):
+        element = HTMLElement.var()
+        self.assertEqual(element.tag_name, 'var')
+        self.assertFalse(element.is_self_closing)
+
+    def test_video_constructor(self):
+        element = HTMLElement.video()
+        self.assertEqual(element.tag_name, 'video')
+        self.assertFalse(element.is_self_closing)
+
+    def test_wbr_constructor(self):
+        element = HTMLElement.wbr()
+        self.assertEqual(element.tag_name, 'wbr')
+        self.assertTrue(element.is_self_closing)
 
     def tearDown(self):
         pass

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
-from html_gen import *
+import re
+import unittest
+
+from html_gen import HTMLElement, HTML_TAG_CONFIG, HTMLElementChildrenError
 from io import StringIO
 
-import unittest
 
 class HTMLGeneratorTests(unittest.TestCase):
     def setUp(self):
-        pass
+        self.current_tag_names = [item["tag_name"] for item in HTML_TAG_CONFIG]
 
     def test_add_child(self):
         test_child = HTMLElement()
@@ -32,13 +34,28 @@ class HTMLGeneratorTests(unittest.TestCase):
                 all_present = False
         self.assertTrue(all_present)
 
-    def test_print_on(self):
+    def test_print_on_basic(self):
         stream = StringIO()
         element = HTMLElement('div')
         element.attributes['class'] = 'column-4 medium'
         element.print_on(stream, newlines=False)
         output = stream.getvalue()
         self.assertEqual('<div class="column-4 medium"></div>', output)
+
+    def test_print_on_nested(self):
+        stream = StringIO()
+        child = HTMLElement('p')
+        child.attributes['class'] = 'column-4 medium'
+        parent = HTMLElement('div', children=[child])
+        parent.attributes['class'] = 'column-4 medium'
+        parent.print_on(stream, newlines=False)
+        output = stream.getvalue()
+        test_out =('<div class="column-4 medium"><p class="column-4 medium">' +
+                  '</p></div>')
+        # we don't care about white spaces or new linesso much
+        output = re.sub('\s{2,}', '', output)
+        output = re.sub(r'\n', '', output)
+        self.assertEqual(test_out, output)
 
     def test_print_on_set_boundmethod(self):
         stream = StringIO()
@@ -47,6 +64,11 @@ class HTMLGeneratorTests(unittest.TestCase):
         element.print_on(stream, newlines=False)
         output = stream.getvalue()
         self.assertEqual('<div class="column-4 medium"></div>', output)
+
+    def test_list_methods(self):
+        method_names = HTMLElement.all_methods
+        for name in self.current_tag_names:
+            self.assertIn(name, method_names)
 
     def tearDown(self):
         pass

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -3,7 +3,7 @@
 import re
 import unittest
 
-from html_gen import (
+from object_database.web.html.html_gen import (
     HTMLElement,
     HTMLTextContent,
     HTML_TAG_CONFIG,
@@ -39,6 +39,27 @@ class HTMLGeneratorTests(unittest.TestCase):
                 all_present = False
         self.assertTrue(all_present)
 
+    def test_add_class_on_empty(self):
+        element = HTMLElement()
+        element.add_class("column-4")
+        class_list = element.attributes["class"].split()
+        self.assertTrue("column-4" in class_list)
+
+    def test_add_class(self):
+        element = HTMLElement(attributes={'class': 'one two'})
+        element.add_class("three")
+        self.assertEqual(element.attributes['class'], "one two three")
+
+    def test_remove_class(self):
+        element = HTMLElement(attributes={"class": "one two three"})
+        element.remove_class("two")
+        self.assertEqual(element.attributes['class'], "one three")
+
+    def test_remove_class_on_empty(self):
+        element = HTMLElement()
+        element.remove_class("test")
+        self.assertTrue("class" not in element.attributes)
+
     def test_print_on_basic(self):
         stream = StringIO()
         element = HTMLElement('div')
@@ -67,7 +88,7 @@ class HTMLGeneratorTests(unittest.TestCase):
         element = HTMLTextContent('this is content')
         element.print_on(stream)
         output = stream.getvalue()
-        test_out = "this is content\n" 
+        test_out = "this is content\n"
         self.assertEqual(test_out, output)
 
     def test_print_on_with_content_nested(self):
@@ -108,6 +129,7 @@ class HTMLGeneratorTests(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class HTMLChainingMethodTests(unittest.TestCase):
     def setUp(self):
         pass
@@ -139,6 +161,7 @@ class HTMLChainingMethodTests(unittest.TestCase):
 
     def tearDown(self):
         pass
+
 
 class HTMLCustomConstructorTests(unittest.TestCase):
     def setUp(self):

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -79,7 +79,7 @@ class HTMLGeneratorTests(unittest.TestCase):
         test_out = ('<div class="column-4 medium"><p class="column-4 medium">' +
                     '</p></div>')
         # we don't care about white spaces or new linesso much
-        output = re.sub('\s{2,}', '', output)
+        output = re.sub(r'\s{2,}', '', output)
         output = re.sub(r'\n', '', output)
         self.assertEqual(test_out, output)
 
@@ -101,7 +101,7 @@ class HTMLGeneratorTests(unittest.TestCase):
         test_out = ('<div class="column-4 medium">this is content' +
                     '</div>')
         # we don't care about white spaces or new linesso much
-        output = re.sub('\s{2,}', '', output)
+        output = re.sub(r'\s{2,}', '', output)
         output = re.sub(r'\n', '', output)
         self.assertEqual(test_out, output)
 

--- a/object_database/web/html/html_gen_tests.py
+++ b/object_database/web/html/html_gen_tests.py
@@ -18,7 +18,9 @@ class HTMLGeneratorTests(unittest.TestCase):
     def test_add_child_self_closing(self):
         test_child = HTMLElement()
         test_parent = HTMLElement(is_self_closing=True)
-        self.assertRaises(HTMLElementChildrenError, test_parent.add_child, test_child)
+
+        self.assertRaises(HTMLElementChildrenError, test_parent.add_child,
+                          test_child)
 
     def test_add_children(self):
         kids = [HTMLElement() for i in range(0, 10)]
@@ -33,6 +35,14 @@ class HTMLGeneratorTests(unittest.TestCase):
     def test_print_on(self):
         stream = StringIO()
         element = HTMLElement('div')
+        element.attributes['class'] = 'column-4 medium'
+        element.print_on(stream, newlines=False)
+        output = stream.getvalue()
+        self.assertEqual('<div class="column-4 medium"></div>', output)
+
+    def test_print_on_set_boundmethod(self):
+        stream = StringIO()
+        element = HTMLElement.div()
         element.attributes['class'] = 'column-4 medium'
         element.print_on(stream, newlines=False)
         output = stream.getvalue()

--- a/object_database/web/html_gen.py
+++ b/object_database/web/html_gen.py
@@ -1,0 +1,123 @@
+from abc import ABC, abstractmethod
+from io import StringIO
+from collections import defaultdict
+
+
+class HTMLElementChildrenError(Exception):
+    pass
+
+
+class HTMLElementError(Exception):
+    pass
+
+
+class AbstractHTMLWriter(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def print_on(self, io_stream, indent=0, indent_increment=4, newlines=True):
+        pass
+
+
+class HTMLElement(AbstractHTMLWriter):
+    def __init__(self, tag_name=None, attributes={}, children=[], is_self_closing=False):
+        self.tag_name = tag_name
+        self.is_self_closing = is_self_closing
+        self.attributes = attributes
+        self.children = children
+        self.parent = None
+
+    def add_child(self, child_element):
+        if self.is_self_closing:
+            raise HTMLElementChildrenError(
+                '{} elements do not have children'.format(self.tag_name))
+        else:
+            self.children.append(child_element)
+            child_element.parent = self
+
+    def add_children(list_of_children):
+        self.children = self.children + list_of_children
+
+    def add_class(self, cls_string):
+        if 'class' in self.attributes:
+            current = self.attributes['class'].split()
+            current_set = set(current)
+            current_set.add(cls_string)
+            self.attributes['class'] = " ".join(list(current_set))
+
+    def remove_class(self, cls_string):
+        if 'class' in self.attributes:
+            current = self.attributes['class'].split()
+            current_set = set(current)
+            if cls_string not in current_set:
+                return
+            current_set.remove(cls_string)
+            self.attributes['class'] = " ".join(list(current_set))
+
+    def __str__(self):
+        stream = StringIO()
+        self.print_on(stream)
+        return stream.getvalue()
+
+    def __repr__(self):
+        return "<{} [{}]>".format(self.__class__.__name__, self.tag_name)
+
+    def print_on(self, io_stream, indent=0, indent_increment=4, newlines=True):
+        self._print_open_tag_on(io_stream, indent, newlines)
+        if not self.is_self_closing:
+            self._print_children_on(io_stream, indent, indent_increment)
+            self._print_close_tag_on(io_stream, indent, newlines)
+
+    def _print_open_tag_on(self, io_stream, indent, newlines):
+        inline_indent = ' ' * indent
+        io_stream.write('{}<{}'.format(inline_indent, self.tag_name))
+        self._print_attributes_on(io_stream)
+        if self.is_self_closing:
+            io_stream.write('/>')
+        else:
+            io_stream.write('>')
+        if newlines:
+            io_stream.write('\n')
+
+    def _print_close_tag_on(self, io_stream, indent, newlines):
+        inline_indent = ' ' * indent
+        io_stream.write('{}</{}>'.format(inline_indent, self.tag_name))
+        if newlines:
+            io_stream.write('\n')
+
+    def _print_attributes_on(self, io_stream):
+        for key, val in self.attributes.items():
+            if len(val) > 0:
+                io_stream.write(
+                    ' {}="{}"'.format(key, val))
+
+    def _print_children_on(self, io_stream, indent=0, indent_increment=4):
+        indent += indent_increment
+        for child in self.children:
+            if isinstance(child, HTMLElement):
+                child.print_on(io_stream, indent, indent_increment)
+            else:
+                io_stream.write(child.__str__())
+
+    @classmethod
+    def div(cls, *args, **kwargs):
+        return cls('div', *args, **kwargs)
+
+    @classmethod
+    def p(cls, *args, **kwargs):
+        return cls('p', *args, **kwargs)
+
+    @classmethod
+    def img(cls, *args, **kwargs):
+        return cls('img', is_self_closing=True, *args, **kwargs)
+
+class HTMLTextContent(AbstractHTMLWriter):
+    def __init__(self, content):
+        super().__init__()
+        self.content = content
+
+    def print_on(self, io_stream, indent=0, indent_increment=4, newlines=True):
+        for line in self.content.split("\n"):
+            inline_indent = " " * indent
+            io_stream.write('{}{}\n'.format(inline_indent, line))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
The PR primarily deals with separating HTML string generation from any other object that spits out HTML.

## Motivation and Context
<!-- Why is this change required? -->
In order to keep classes like Cells and friends as simple as possible, and to prevent easy errors on the part of programmers, it's a good idea to avoid writing HTML by hand.
  
<!-- What problem does it solve? -->
With the classes introduced in this PR, we can now create elements in Python without having to worry about how the strings look or how to print children, etc.
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
The HTML generation classes and their tests can be found in `object_database/web/html`
  
### HTML String Generation ###
The idea here is fairly simple: any class that subclasses `AbstractHTMLWriter` (for now this is only `HTMLElement` and `HTMLTextContent`) must implement a method called `print_on` whose first argument is some kind of stream.
  
In our case we are using `StringIO` to build strings in a streamlike fashion.
  
When `__str__` is called on any `HTMLElement` instance, it will create a new stream and pass it to its own `print_on`, which handles printing open tags, attributes, children, and close tags. Printing children is pretty simple: it will just call `print_on` and pass the working stream to each of its children in order, and so on recursively down the chain.
  
To test this out, try something like this:
```python
parent = HTMLElement('div')
parent.add_class("container")
child_one = HTMLElement('img', is_self_closing=True)
child_two = HTMLElement('p')
child_content = HTMLTextContent("This is the paragraph content")
child_two.add_child(child_content)
parent.add_children([child_one, child_two])
print(parent)
```
Now this code is somewhat verbose, which is why we added other ways to do this (see chaining and constructors sections below)
  
### Chaining ###
The example in the section above shows how writing this HTML can be fairly explicit. But we've added the convenience of chaining most public methods (ie, returning `self`) so that we can do things like:
```python
element = HTMLElement('div').with_children(
    HTMLElement('img', is_self_closing=True).add_class("primary-img"),
    HTMLElement('p').add_class("main-typography").add_child(
        HTMLTextContent("This is the paragraph content")
    )
)
print(element)
```
This allows for some better composition.
  
### Special Constructors ###
Some HTML5 elements are "self-closing," meaning they don't have any children nor to they use a totally separate closing tag. For example, `<div>Something</div>` is not self closing, while `<img src="http://foo.com/img.jpg />` **is** self closing.
  
When using the plain class constructor, one would need to know ahead of time whether or not the tag is self closing or not the generate valid HTML5. So we decided to dyamically add class methods to `HTMLElement` that "do the right thing" for you:
  
````python
div = HTMLElement.div().add_class("main")
img = HTMLElement.img().add_class("big")
div.add_child(img)
print(div)
# <div class="main">
#     <img class="big" />
# </div>
````
  
### Cells Proof of Concept ###
We have successfully used these classes as drop-in replacements for the HTML that is generated in
three `Cells` classes: `Card`, `CardTitle`, and `CollapsiblePanel`. So far these appear to load and work fine when running the database test server.
  
## How Has This Been Tested?
<!-- Describe in reasonable detail how you tested your changes. -->
We have created a full set of tests in `object_database/web/html/html_gen_tests.py` and all are currently passing.
  
All current Cells tests are also passing, as is the regular full test suite.
  
For testing the output, we run `object_database/frontends/object_database_webtest.py` and then load all relevant services in the browser, checking the console as we go. So far any errors that do appear in the browser console are identical to those on the current (as of this writing) `dev` branch and are non-fatal.
  
We have also run flake8 on the changed files and everything seems to be ok linting wise.
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. -->
  
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.