### PR TITLE
Some small improvements to `Cells`

### DIFF
--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -435,9 +435,11 @@ class ActiveWebService(ServiceBase):
             # we keep a list of sessions.)
             sessionState._reset(cells)
 
-            cells.root.setRootSerializationContext(self.db.serializationContext)
-            cells.root.setChild(Subscribed(lambda: self.displayForPathAndQueryArgs(path, queryArgs)))
-            cells.root.setContext(SessionState, sessionState)
+            cells = cells.withRoot(
+                Subscribed(lambda: self.displayForPathAndQueryArgs(path, queryArgs)),
+                serialization_context=self.db.serializationContext,
+                session_state=sessionState
+            )
 
             cellsTaskThread = threading.Thread(target=cells.processTasks)
             cellsTaskThread.daemon = True

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -487,11 +487,10 @@ class Cells:
     def childrenWithExceptions(self):
         return self._root.findChildrenMatching(lambda cell: isinstance(cell, Traceback))
 
-    def findChildrenByTag(self, tag, stopSearchingAtTag=True, isRoot=True):
+    def findChildrenByTag(self, tag, stopSearchingAtFoundTag=True):
         return self._root.findChildrenByTag(
             tag,
-            stopSearchingAtTag=stopSearchingAtTag,
-            isRoot=isRoot
+            stopSearchingAtFoundTag=stopSearchingAtFoundTag
         )
 
     def findChildrenMatching(self, filtr):
@@ -691,23 +690,23 @@ class Cell:
         self._tag = tag
         return self
 
-    def findChildrenByTag(self, tag, stopSearchingAtTag=True, isRoot=True):
+    def findChildrenByTag(self, tag, stopSearchingAtFoundTag=False):
         """Search the cell and its children for all cells with the given tag.
 
-        If `stopSearchingAtTag`, then if we encounter a non-None tag that doesn't
-        match, stop searching immediately.
+        If `stopSearchingAtFoundTag`, we don't search recursively the children of a
+        cell that matched our search.
         """
         cells = []
 
         if self._tag == tag:
             cells.append(self)
-
-        if self._tag is not None and stopSearchingAtTag and not isRoot:
-            return cells
+            if stopSearchingAtFoundTag:
+                return cells
 
         for child in self.children:
-            cells.extend(self.children[child].findChildrenByTag(
-                tag, stopSearchingAtTag, False))
+            cells.extend(
+                self.children[child].findChildrenByTag(tag, stopSearchingAtFoundTag)
+            )
 
         return cells
 

--- a/object_database/web/cells.py
+++ b/object_database/web/cells.py
@@ -984,10 +984,12 @@ class Modal(Cell):
         buttonActions - a dict from string to a button action function.
         """
         super().__init__()
-        self.title = title
-        self.message = message
-        self.buttons = {f"____button_{k}__": Button(
-            k, v) for k, v in buttonActions.items()}
+        self.title = Cell.makeCell(title).tagged("title")
+        self.message = Cell.makeCell(message).tagged("message")
+        self.buttons = {
+            f"____button_{k}__": Button(k, v).tagged(k)
+            for k, v in buttonActions.items()
+        }
 
     def recalculate(self):
         self.contents = (
@@ -1011,8 +1013,8 @@ class Modal(Cell):
             .replace("__buttons__", " ".join(self.buttons))
         )
         self.children = dict(self.buttons)
-        self.children["____title__"] = Cell.makeCell(self.title)
-        self.children["____message__"] = Cell.makeCell(self.message)
+        self.children["____title__"] = self.title
+        self.children["____message__"] = self.message
 
 
 class Octicon(Cell):

--- a/object_database/web/cells_test.py
+++ b/object_database/web/cells_test.py
@@ -64,13 +64,13 @@ class CellsTests(unittest.TestCase):
             Container("HI2")
         ]
         pairCell = Sequence(pair)
-        self.cells.root.setChild(pairCell)
+        self.cells.withRoot(pairCell)
 
         msgs = self.cells.renderMessages()
 
-        expectedCells = [self.cells.root, pairCell, pair[0], pair[1]]
+        expectedCells = [self.cells._root, pairCell, pair[0], pair[1]]
 
-        self.assertTrue(self.cells.root in self.cells)
+        self.assertTrue(self.cells._root in self.cells)
         self.assertTrue(pairCell in self.cells)
         self.assertTrue(pair[0] in self.cells)
         self.assertTrue(pair[1] in self.cells)
@@ -90,7 +90,7 @@ class CellsTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            set(messages[self.cells.root.identity]['replacements'].values()),
+            set(messages[self.cells._root.identity]['replacements'].values()),
             set([pairCell.identity])
         )
 
@@ -100,7 +100,7 @@ class CellsTests(unittest.TestCase):
             Container("HI2")
         ]
 
-        self.cells.root.setChild(
+        self.cells.withRoot(
             Sequence(pair)
         )
 
@@ -116,7 +116,7 @@ class CellsTests(unittest.TestCase):
         c2 = Card(Text("HI2"))
         slot = Slot(0)
 
-        self.cells.root.setChild(
+        self.cells.withRoot(
             Subscribed(lambda: c1 if slot.get() else c2)
         )
 
@@ -126,10 +126,10 @@ class CellsTests(unittest.TestCase):
         slot.set(0)
         self.cells.renderMessages()
 
-        self.assertFalse(self.cells.root.childrenWithExceptions())
+        self.assertFalse(self.cells.childrenWithExceptions())
 
     def test_cells_subscriptions(self):
-        self.cells.root.setChild(
+        self.cells.withRoot(
             Subscribed(
                 lambda: Sequence([
                     Span("Thing(k=%s).x = %s" % (thing.k, thing.x))
@@ -173,7 +173,7 @@ class CellsTests(unittest.TestCase):
 
             return res
 
-        self.cells.root.setChild(Subscribed(checkThing2s))
+        self.cells.withRoot(Subscribed(checkThing2s))
 
         self.cells.renderMessages()
 
@@ -185,7 +185,7 @@ class CellsTests(unittest.TestCase):
         # cell count, and that we send deletion messages
 
         # subscribes to the set of cells with k=0 and displays something
-        self.cells.root.setChild(
+        self.cells.withRoot(
             SubscribedSequence(
                 lambda: Thing.lookupAll(k=0),
                 lambda thing: Subscribed(
@@ -221,7 +221,7 @@ class CellsTests(unittest.TestCase):
             db.subscribeToSchema(test_schema)
             cells = Cells(db)
 
-            cells.root.setChild(cell)
+            cells.withRoot(cell)
 
             initFn(db, cells)
 
@@ -335,7 +335,7 @@ class CellsTests(unittest.TestCase):
         def any_x(X):
             return Text(X.x).tagged("display " + str(X.x))
 
-        self.cells.root.setChild(
+        self.cells.withRoot(
             Card(X(0)).withContext(size="small") +
             Card(X(1)).withContext(size="large") +
             Card(X(2)).withContext(size="something else") +
@@ -344,7 +344,7 @@ class CellsTests(unittest.TestCase):
 
         self.cells.renderMessages()
 
-        self.assertTrue(self.cells.root.findChildrenByTag("small display 0"))
-        self.assertTrue(self.cells.root.findChildrenByTag("large display 1"))
-        self.assertTrue(self.cells.root.findChildrenByTag("sized display 2"))
-        self.assertTrue(self.cells.root.findChildrenByTag("display 3"))
+        self.assertTrue(self.cells.findChildrenByTag("small display 0"))
+        self.assertTrue(self.cells.findChildrenByTag("large display 1"))
+        self.assertTrue(self.cells.findChildrenByTag("sized display 2"))
+        self.assertTrue(self.cells.findChildrenByTag("display 3"))


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
Cells is a bit of a leaky wrapper of a Cell tree. This PR formalizes a couple of things.

## Approach
- Remove the `root` property of a `Cells` object and provide methods that operate on the contained `Cell` objects, such as `withRoot`, `childrenWithExceptions`, `findChildrenByTag`, and `findChildrenMatching`.
- Additionally, `withRoot` implements the common initialization pattern for a `Cells` object by setting the root, and optionally also the serialization context and the session state.
- Rename `SessionState`'s `ensure`, which is confusing, to `setdefault` which is less confusing because the semantics of that method mimic those of `setdefault` of dictionaries.
- Implement default tagging of `Modal` child cells, because the emerging testing pattern is to grab a tagged Modal, then find elements within the Modal using `findChildrenByTag`.
- Change the semantics of `findChildrenByTag`. By default (`stopSearchingAtTag=True`) it would not search beyond any tagged cell. This is problematic because we would like to be able to move uniquely tagged cells under other tagged cells without breaking tests. As it stood we would have had to either pass `stopSearchingAtTag=False` in anticipation of these changes, or adapt the tests each time we tagged a cell that had tagged children. None of these was a good solution. In general, stopping the search at a tagged cell doesn't seem to align with a usage pattern. The semantics of the new flag `stopSearchingAtFoundTag` stops the recursive search at a node with a tag that matches the one we're searching. This seems potentially useful, but honestly, since we have zero use-cases for it at the moment, I'm inclined to rip it out.

## How Has This Been Tested?
- TravisCI tests are passing

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.