### PR TITLE
Propagate Log-Level to SubprocessServiceManager

### DIFF
--- a/object_database/frontends/object_database_webtest.py
+++ b/object_database/frontends/object_database_webtest.py
@@ -14,7 +14,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-
 import os
 import sys
 import tempfile
@@ -51,9 +50,11 @@ def main(argv=None):
 
     token = genToken()
     port = 8020
+    loglevel_name = 'INFO'
+
     with tempfile.TemporaryDirectory() as tmpDirName:
         try:
-            server = start_service_manager(tmpDirName, port, token)
+            server = start_service_manager(tmpDirName, port, token, loglevel_name=loglevel_name)
 
             database = connect("localhost", port, token, retry=True)
             database.subscribeToSchema(core_schema, service_schema, active_webservice_schema)
@@ -65,7 +66,7 @@ def main(argv=None):
                 database, service,
                 ['--port', '8000',
                  '--host', '0.0.0.0',
-                 '--log-level', 'INFO']
+                 '--log-level', loglevel_name]
             )
 
             ActiveWebService.setLoginPlugin(
@@ -80,17 +81,21 @@ def main(argv=None):
                 ServiceManager.startService("ActiveWebService", 1)
 
             with database.transaction():
-                service = ServiceManager.createOrUpdateService(UninitializableService, "UninitializableService", target_count=1)
-
+                service = ServiceManager.createOrUpdateService(
+                    UninitializableService, "UninitializableService", target_count=1
+                )
             with database.transaction():
-                service = ServiceManager.createOrUpdateService(HappyService, "HappyService", target_count=1)
-
+                service = ServiceManager.createOrUpdateService(
+                    HappyService, "HappyService", target_count=1
+                )
             with database.transaction():
-                service = ServiceManager.createOrUpdateService(GraphDisplayService, "GraphDisplayService", target_count=1)
-
+                service = ServiceManager.createOrUpdateService(
+                    GraphDisplayService, "GraphDisplayService", target_count=1
+                )
             with database.transaction():
-                service = ServiceManager.createOrUpdateService(TextEditorService, "TextEditorService", target_count=1)
-
+                service = ServiceManager.createOrUpdateService(
+                    TextEditorService, "TextEditorService", target_count=1
+                )
             while True:
                 time.sleep(.1)
         finally:

--- a/object_database/frontends/service_entrypoint.py
+++ b/object_database/frontends/service_entrypoint.py
@@ -20,7 +20,7 @@ import sys
 import traceback
 
 from object_database import connect
-from object_database.util import checkLogLevelValidity, configureLogging
+from object_database.util import validateLogLevel, configureLogging
 from object_database.service_manager.Codebase import setCodebaseInstantiationDirectory
 from object_database.service_manager.ServiceWorker import ServiceWorker
 
@@ -40,7 +40,7 @@ def main(argv):
     parsedArgs = parser.parse_args(argv[1:])
 
     level = parsedArgs.log_level.upper()
-    checkLogLevelValidity(level)
+    level = validateLogLevel(level, fallback='INFO')
 
     configureLogging(preamble=parsedArgs.instanceid[:8], level=level)
 

--- a/object_database/service_manager/ServiceManager.py
+++ b/object_database/service_manager/ServiceManager.py
@@ -29,7 +29,8 @@ import sys
 class ServiceManager(object):
     DEFAULT_SHUTDOWN_TIMEOUT = 10.0
 
-    def __init__(self, dbConnectionFactory, sourceDir, isMaster, ownHostname, maxGbRam=4, maxCores=4, shutdownTimeout=None):
+    def __init__(self, dbConnectionFactory, sourceDir, isMaster, ownHostname,
+                 maxGbRam=4, maxCores=4, shutdownTimeout=None):
         object.__init__(self)
         self.shutdownTimeout = shutdownTimeout or ServiceManager.DEFAULT_SHUTDOWN_TIMEOUT
         self.ownHostname = ownHostname

--- a/object_database/service_manager/ServiceManagerTestCommon.py
+++ b/object_database/service_manager/ServiceManagerTestCommon.py
@@ -12,6 +12,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import logging
 import os
 import subprocess
 import sys
@@ -47,10 +48,16 @@ class ServiceManagerTestCommon(object):
         self.token = genToken()
         self.tempDirObj = tempfile.TemporaryDirectory()
         self.tempDirectoryName = self.tempDirObj.name
-        object_database.service_manager.Codebase.setCodebaseInstantiationDirectory(self.tempDirectoryName, forceReset=True)
+        object_database.service_manager.Codebase.setCodebaseInstantiationDirectory(
+            self.tempDirectoryName, forceReset=True
+        )
 
         os.makedirs(os.path.join(self.tempDirectoryName, 'source'))
         os.makedirs(os.path.join(self.tempDirectoryName, 'storage'))
+
+        logLevelName = logging.getLevelName(
+            logging.getLogger(__name__).getEffectiveLevel()
+        )
 
         if not VERBOSE:
             kwargs = {'stdout': subprocess.DEVNULL, 'stderr': subprocess.DEVNULL}
@@ -67,7 +74,8 @@ class ServiceManagerTestCommon(object):
                     '--storage', os.path.join(self.tempDirectoryName, 'storage'),
                     '--service-token', self.token,
                     '--shutdownTimeout', '1.0',
-                    '--ssl-path', os.path.join(ownDir, '..', '..', 'testcert.cert')
+                    '--ssl-path', os.path.join(ownDir, '..', '..', 'testcert.cert'),
+                    '--log-level', logLevelName
                 ],
                 **kwargs
             )

--- a/object_database/service_manager/SubprocessServiceManager.py
+++ b/object_database/service_manager/SubprocessServiceManager.py
@@ -23,6 +23,7 @@ import traceback
 
 from object_database.service_manager.ServiceManager import ServiceManager
 from object_database.service_manager.ServiceSchema import service_schema
+from object_database.util import validateLogLevel
 from object_database import connect
 
 
@@ -52,13 +53,13 @@ class SubprocessServiceManager(ServiceManager):
     def __init__(self, ownHostname, host, port,
                  sourceDir, storageDir, serviceToken,
                  isMaster, maxGbRam=4, maxCores=4, logfileDirectory=None,
-                 shutdownTimeout=None, errorLogsOnly=False):
+                 shutdownTimeout=None, logLevelName="INFO"):
         self.host = host
         self.port = port
         self.storageDir = storageDir
         self.serviceToken = serviceToken
         self.logfileDirectory = logfileDirectory
-        self.errorLogsOnly = errorLogsOnly
+        self.logLevelName = validateLogLevel(logLevelName, fallback='INFO')
 
         self.lock = threading.Lock()
 
@@ -108,8 +109,9 @@ class SubprocessServiceManager(ServiceManager):
                         instanceIdentity,
                         os.path.join(self.sourceDir, instanceIdentity),
                         os.path.join(self.storageDir, instanceIdentity),
-                        self.serviceToken
-                    ] + (['--log-level', 'ERROR'] if self.errorLogsOnly else []),
+                        self.serviceToken,
+                        '--log-level', self.logLevelName
+                    ],
                     cwd=self.storageDir,
                     stdin=subprocess.DEVNULL,
                     stdout=output_file,

--- a/object_database/test_util.py
+++ b/object_database/test_util.py
@@ -141,8 +141,9 @@ def autoconfigure_and_start_service_manager(port=None, auth_token=None, loglevel
     auth_token = auth_token or genToken()
 
     if loglevel_name is None:
-        loglevel = logging.getLogger(__name__).getEffectiveLevel()
-        loglevel_name = logging.getLevelName(loglevel)
+        loglevel_name = logging.getLevelName(
+            logging.getLogger(__name__).getEffectiveLevel()
+        )
 
     tempDirObj = tempfile.TemporaryDirectory()
     tempDirectoryName = tempDirObj.name

--- a/object_database/util.py
+++ b/object_database/util.py
@@ -255,8 +255,13 @@ def tokenFromString(text):
 VALID_LOG_LEVELS = ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
 
 
-def checkLogLevelValidity(level: str):
-    if level not in VALID_LOG_LEVELS:
+def validateLogLevel(level: str, fallback=None):
+    if level in VALID_LOG_LEVELS:
+        return level
+    elif fallback in VALID_LOG_LEVELS:
+        logging.warning(f"Invalid log-level '{level}', falling back to {fallback}")
+        return fallback
+    else:
         raise Exception(
             "invalid log-level value: {level}. Must be one of {options}"
             .format(level=level, options=VALID_LOG_LEVELS)

--- a/object_database/web/ActiveWebService.py
+++ b/object_database/web/ActiveWebService.py
@@ -21,7 +21,7 @@ import threading
 import gevent.socket
 import gevent.queue
 
-from object_database.util import genToken, checkLogLevelValidity
+from object_database.util import genToken, validateLogLevel
 from object_database import ServiceBase, service_schema, Indexed
 from object_database.web.AuthPlugin import AuthPluginBase, LdapAuthPlugin
 from object_database.web.LoginPlugin import LoginIpPlugin
@@ -138,7 +138,7 @@ class ActiveWebService(ServiceBase):
                 c = Configuration(service=serviceObject)
 
             level_name = parsedArgs.log_level.upper()
-            checkLogLevelValidity(level_name)
+            level_name = validateLogLevel(level_name, fallback='INFO')
 
             c.port = parsedArgs.port
             c.hostname = parsedArgs.hostname


### PR DESCRIPTION
## Motivation and Context
One might expect the default behavior would be for the `SubprocessServiceManager` to propagate its log-level, but it was defaulting to `INFO`, with the only other option being `ERROR` when a flag was set in its `__init__` method. This lead to the unexpected behavior of running tests with `--log-level=WARNING` but seeing a bunch of `INFO` logs, or more annoyingly setting `--log-level=DEBUG` and only seeing some of the debug logs because the SubprocessServiceManager was always stood up with `INFO` log-level.

This PR fixes these problem by propagating the log-level of the caller to the created processes unless a log-level is requested for those processes.

## Approach
- `SubprocessServiceManager` accepts a `logLevelName` string to its `__init__` method and propagates it to its sub-processes.
- Entrypoints to `SubprocessServiceManager` allow a logLevel override, but otherwise propagate their log-level
- Renamed `checkLogLevelValidity` to `validateLogLevel` and added optional fallback semantics (when the `fallback` kwarg is set to a valid log-level, it will be used if the provided loglevel is invalid and issue a WARNING that it is using the fallback. This is probably the behavior most commonly desired: don't fail if the log-level is invalid, but warn about it and use some sensible value.

## How Has This Been Tested?
- TravisCI tests pass
- when manually running tests, the chosen log-level is honored by subprocesses.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (`validateLogLevel` now has fallback)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points,  and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.