### PR TITLE
Implement short-circuit conditional logic

### DIFF
--- a/nativepython/native_ast.py
+++ b/nativepython/native_ast.py
@@ -254,7 +254,7 @@ def expr_str(self):
     if self.matches.Cast:
         return "cast(%s,%s)" % (str(self.left), str(self.to_type))
     if self.matches.Binop:
-        return "((%s)%s(%s))" % (str(self.l), str(self.op), str(self.r))
+        return "((%s)%s(%s))" % (str(self.left), str(self.op), str(self.right))
     if self.matches.Unaryop:
         return "(%s(%s))" % (str(self.op), str(self.operand))
     if self.matches.Variable:

--- a/nativepython/tests/conversion_test.py
+++ b/nativepython/tests/conversion_test.py
@@ -55,17 +55,42 @@ class TestCompilationStructures(unittest.TestCase):
 
         self.checkFunctionOfIntegers(f)
 
-    def test_boolean_operators(self):
+    def test_boolean_and(self):
         @Compiled
         def f(x: int, y: int, z: int) -> bool:
             return x and y and z
 
-        self.assertEqual(f(0, 1, 1), False)
-        self.assertEqual(f(0, 0, 1), False)
         self.assertEqual(f(0, 0, 0), False)
+        self.assertEqual(f(0, 0, 1), False)
+        self.assertEqual(f(0, 1, 0), False)
+        self.assertEqual(f(0, 1, 1), False)
         self.assertEqual(f(1, 0, 0), False)
+        self.assertEqual(f(1, 0, 1), False)
         self.assertEqual(f(1, 1, 0), False)
         self.assertEqual(f(1, 1, 1), True)
+
+    def test_boolean_or(self):
+        @Compiled
+        def f(x: int, y: int, z: int) -> bool:
+            return x or y or z
+
+        self.assertEqual(f(0, 0, 0), False)
+        self.assertEqual(f(0, 0, 1), True)
+        self.assertEqual(f(0, 1, 0), True)
+        self.assertEqual(f(0, 1, 1), True)
+        self.assertEqual(f(1, 0, 0), True)
+        self.assertEqual(f(1, 0, 1), True)
+        self.assertEqual(f(1, 1, 0), True)
+        self.assertEqual(f(1, 1, 1), True)
+
+    def test_boolean_operators(self):
+        @Compiled
+        def f(x: int, y: int, z: str) -> bool:
+            return x and y and z
+
+        self.assertEqual(f(0, 1, "s"), False)
+        with self.assertRaises(TypeError):
+            f(1, 1, "s")
 
     def test_object_to_int_conversion(self):
         @Compiled

--- a/nativepython/tests/list_of_compilation_test.py
+++ b/nativepython/tests/list_of_compilation_test.py
@@ -349,3 +349,11 @@ class TestListOfCompilation(unittest.TestCase):
         y = dupList(x)
         x[0] = 100
         self.assertEqual(y[0], 1)
+
+    def test_list_short_circut_if(self):
+        @Compiled
+        def chkList(x: ListOf(int)):
+            return len(x) > 0 and x[0]
+
+        x = ListOf(int)([])
+        self.assertFalse(chkList(x))

--- a/nativepython/typed_expression.py
+++ b/nativepython/typed_expression.py
@@ -140,6 +140,13 @@ class TypedExpression(object):
     def toBool(self):
         return self.expr_type.convert_to_type(self.context, self, typeWrapper(Bool))
 
+    @staticmethod
+    def asBool(typedExpressionOrNone):
+        if typedExpressionOrNone is not None:
+            return typedExpressionOrNone.toBool()
+        else:
+            return None
+
     def __str__(self):
         return "TypedExpression(%s%s)" % (self.expr_type, ",[ref]" if self.isReference else "")
 


### PR DESCRIPTION
## Motivation and Context
Without short-circuit conditional logic evaluating, the following condition will erroneously throw an `IndexError` (out of bounds) on empty lists:
```
if len(lst) > 0 and lst[0]:
    <some_code>
```
We want to allow short-circuit conditional logic because otherwise the code above will need to be refactored to code with deeper nesting (as shown below), which is not desirable:
```
if len(lst) > 0:
    if lst[0]:
        <some_code>
```

## Approach
Build nested scopes as we convert each element of a compound boolean (AND or OR) expression. That way intermediate expression evaluations are generated just when they are needed (in the appropriate nested scope), avoiding problems like the one in the example above

## How Has This Been Tested?
- Wrote a test derived from the example above
- Wrote a second test where the 2nd part of the boolean expression always throws an exception and tested that the exception is thrown only when the 1st part of the boolean expression does not resolve the entire expression thanks to short-circuiting.
- Extended a boolean expression test to exhaustively test the 3-argument AND and OR expressions
- All the existing tests are still passing
- Pointing our private repo this branch does cause any tests to break

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.