### PR TITLE
Makefile: fix `make lib` rule 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,6 @@ CPP_FLAGS = -std=c++14 -O2 -Wall -pthread -DNDEBUG -g -fwrapv               \
 
 LINKER_FLAGS = -Wl,-O1 \
                -Wl,-Bsymbolic-functions \
-               -Wl,-Bsymbolic-functions \
-               -Wl,-Bsymbolic-functions \
-               -Wl,-z,relro \
                -Wl,-z,relro
 
 SHAREDLIB_FLAGS = -pthread -shared -g -fstack-protector-strong \

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extra_compile_args = [
     '-std=c++14',
     '-Wno-sign-compare',
     '-Wno-narrowing',
-    '-Wno-unused-'
+    '-Wno-unused-variable'
 ]
 
 ext_modules = [


### PR DESCRIPTION
## Motivation and Context
`make lib` was not working properly with the virtual-env flow because we were not adding the necessary `-I` flag to find the numpy libraries.
The way this was broken was that if after a `make install` we modified a `.cpp/.hpp` file and tried to run a test, `test.py` would try to run `make lib` which would fail saying it couldn't find the necessary numpy
headers:
```
typed_python/_types.cpp:2:10: fatal error: numpy/arrayobject.h: No such file or directory
```
<!-- Provide a general summary of your changes in the Title above -->

<!-- Why is this change required? -->
<!-- What problem does it solve? -->
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
Added `-I$(VIRTUAL_ENV)/lib/python3.6/site-packages/numpy/core/include` to `CPP_FLAGS`

Also did a refactoring of `Makefile` to break up some very long lines and to refactor common argument sequences (see `LINKER_FLAGS` and `SHAREDLIB_FLAGS`)

## How Has This Been Tested?
TravisCI is happy

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.