### PR TITLE
Support callable Class objects

### DIFF
--- a/typed_python/PyClassInstance.hpp
+++ b/typed_python/PyClassInstance.hpp
@@ -26,6 +26,8 @@ public:
 
     PyObject* tp_getattr_concrete(PyObject* pyAttrName, const char* attrName);
 
+    PyObject* tp_call_concrete(PyObject* args, PyObject* kwargs);
+
     PyObject* pyUnaryOperatorConcrete(const char* op, const char* opErr);
 
     PyObject* pyOperatorConcrete(PyObject* rhs, const char* op, const char* opErr);

--- a/typed_python/PyFunctionInstance.hpp
+++ b/typed_python/PyFunctionInstance.hpp
@@ -14,6 +14,8 @@ public:
 
     static std::pair<bool, PyObject*> tryToCall(const Function* f, PyObject* arg0=nullptr, PyObject* arg1=nullptr, PyObject* arg2=nullptr);
 
+    static std::pair<bool, PyObject*> tryToCallAnyOverload(const Function* f, PyObject* self, PyObject* args, PyObject* kwargs);
+
     static std::pair<bool, PyObject*> tryToCallOverload(const Function::Overload& f, PyObject* self, PyObject* args, PyObject* kwargs);
 
     //perform a linear scan of all specializations contained in overload and attempt to dispatch to each one.

--- a/typed_python/function_types_test.py
+++ b/typed_python/function_types_test.py
@@ -40,7 +40,11 @@ class NativeFunctionTypesTests(unittest.TestCase):
 
     def test_create_function_with_kwargs_and_star_args_and_defaults(self):
         @Function
-        def f(x: int, y=30, z: None = None, *args: TupleOf(float), **kwargs: ConstDict(str, float)) -> int:
+        def f(x: int,
+              y=30,
+              z: None = None,
+              *args: TupleOf(float),
+              **kwargs: ConstDict(str, float)) -> int:
             return x + 1
 
         self.assertEqual(len(f.overloads), 1)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Motivation and Context
When we define the `__call__` method of a type derived from `Class`, we want the objects of that type to be callable:
```       
class CallableClass(Class):
    def __call__(self, *args, **kwargs):
        return 42

obj = CallableClass()
self.assertEqual(obj(), 42)
```

## Approach
Implement `tp_call_concrete` for PyClassInstance objects. Its implementation conveniently calls the helper method `callMemberFunction`

## How Has This Been Tested?
I wrote a unit-test which was failing before these changes but now is passing

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.