### PR TITLE
Popover Bugfix

### DIFF
--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1757,11 +1757,11 @@ class Popover(Cell):
             .set_attribute('style', self._divStyle())
             .with_children(
                 HTMLElement.a()
-                .set_attribute('container', 'body')
                 .set_attribute('href', '#popmain_%s' % self.identity)
                 .set_attribute('data-toggle', 'popover')
                 .set_attribute('data-trigger', 'focus')
                 .set_attribute('data-bind', '#pop_%s' % self.identity)
+                .set_attribute('data-placement', 'bottom')
                 .set_attribute('role', 'button')
                 .add_classes(['btn', 'btn-xs'])
                 .add_child(HTMLTextContent('____contents__')),
@@ -1772,9 +1772,6 @@ class Popover(Cell):
                     HTMLElement.div()
                     .set_attribute('id', 'pop_%s' % self.identity)
                     .with_children(
-                        HTMLElement.div()
-                        .add_class('data-placement')
-                        .add_child(HTMLTextContent('bottom')),
 
                         HTMLElement.div()
                         .add_class('data-title')
@@ -1791,7 +1788,6 @@ class Popover(Cell):
                 )
             )
         )
-        self._logger.info(self.contents)
 
     def sortsAs(self):
         if '____title__' in self.children:

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1753,11 +1753,11 @@ class Popover(Cell):
         }
 
     def recalculate(self):
-        self.contents = str(
-            HTMLElement.div()
+        self.contents = str(HTMLElement.div()
             .set_attribute('style', self._divStyle())
             .with_children(
                 HTMLElement.a()
+                .set_attribute('container', 'body')
                 .set_attribute('href', '#popmain_%s' % self.identity)
                 .set_attribute('data-toggle', 'popover')
                 .set_attribute('data-trigger', 'focus')
@@ -1770,7 +1770,7 @@ class Popover(Cell):
                 .set_attribute('style', 'display:none;')
                 .add_child(
                     HTMLElement.div()
-                    .set_attribute('id', '#pop_%s' % self.identity)
+                    .set_attribute('id', 'pop_%s' % self.identity)
                     .with_children(
                         HTMLElement.div()
                         .add_class('data-placement')
@@ -1791,6 +1791,7 @@ class Popover(Cell):
                 )
             )
         )
+        self._logger.info(self.contents)
 
     def sortsAs(self):
         if '____title__' in self.children:

--- a/object_database/web/cells/cells.py
+++ b/object_database/web/cells/cells.py
@@ -1753,7 +1753,8 @@ class Popover(Cell):
         }
 
     def recalculate(self):
-        self.contents = str(HTMLElement.div()
+        self.contents = str(
+            HTMLElement.div()
             .set_attribute('style', self._divStyle())
             .with_children(
                 HTMLElement.a()
@@ -2360,7 +2361,8 @@ class ButtonGroup(Cell):
     def recalculate(self):
         self.children = {
             f'____{i}__': self.buttons[i] for i in range(len(self.buttons))}
-        innerButtons = HTMLTextContent(" ".join(f"____{i}__" for i in range(len(self.buttons))))
+        innerButtons = HTMLTextContent(
+            " ".join(f"____{i}__" for i in range(len(self.buttons))))
         self.contents = str(
             HTMLElement.div()
             .add_class('btn-group')

--- a/object_database/web/content/CellHandler.js
+++ b/object_database/web/content/CellHandler.js
@@ -62,8 +62,12 @@ class CellHandler {
             content: function () {
                 return getChildProp(this, 'content');
             },
-            placement: function () {
-                return getChildProp(this, 'placement');
+            placement: function (popperEl, triggeringEl) {
+                let placement = triggeringEl.dataset.placement;
+                if(placement == undefined){
+                    return "bottom";
+                }
+                return placement;
             }
         });
         $('.popover-dismiss').popover({
@@ -87,7 +91,7 @@ class CellHandler {
         // Elsewhere, update popovers first
         // Now we evaluate scripts coming
         // across the wire.
-        updatePopovers();
+        this.updatePopovers();
         while(this.postscripts.length){
             let postscript = this.postscripts.pop();
             try{

--- a/object_database/web/content/page.html
+++ b/object_database/web/content/page.html
@@ -89,28 +89,7 @@
 
      return new Float64Array(buf)
  }
- function updatePopovers() {
-     $('[data-toggle="popover"]').popover({
-         html: true,
-         container: 'body',
-         title: function () {
-             return getChildProp(this, 'title');
-         },
-         content: function () {
-             return getChildProp(this, 'content');
-         },
-         placement: function (popoverEl, triggeringEl) {
-             let placement = triggeringEl.dataset.placement;
-             if(placement == undefined){
-                 return "bottom";
-             }
-             return placement;
-         }
-     });
-     $('.popover-dismiss').popover({
-         trigger: 'focus'
-     });
- }
+ 
 </script>
 </head>
 <body>

--- a/object_database/web/content/page.html
+++ b/object_database/web/content/page.html
@@ -99,8 +99,12 @@
          content: function () {
              return getChildProp(this, 'content');
          },
-         placement: function () {
-             return getChildProp(this, 'placement');
+         placement: function (popoverEl, triggeringEl) {
+             let placement = triggeringEl.dataset.placement;
+             if(placement == undefined){
+                 return "bottom";
+             }
+             return placement;
          }
      });
      $('.popover-dismiss').popover({
@@ -136,7 +140,7 @@ $(function () {
     });
 })
 const getChildProp = function(el, child) {
-  return $('.data-' + child, $(el).attr('data-bind')).html();
+     return $('.data-' + child, $(el).attr('data-bind')).html();
 };
 
 $('[data-poload]').on('show.bs.dropdown', function (arg) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
A fix for Popover rendering, which broke after changes to HTML generation.
## Motivation and Context
<!-- Why is this change required? -->
<!-- What problem does it solve? -->
Since the switch to `HTMLElement` based generation in the `Popover` cell, popover actions were not working inside the browser and were throwing a very cryptic jQuery-nested error.
<!--  If it fixes an open issue, please link to the issue here.-->

## Approach
<!-- Describe your changes in reasonable detail -->
The source of the problem had several aspects. The `updatePopovers()` function deals with re-rendering important information in any popover by way of internal function calls (ie, `title`, `content`, and `placement`). 
  
In the old setup, these functions looked for the inner HTML contents of nested `div`s in the popover target in order to get information about the title, content, and placement. It was the latter value -- `placement` -- that ended up being the root of the problem. Unlike the other functions in `popover` for content and title, the `placement` callback gets passed *different arguments and also changes the context of `this`* compared to the other two.
  
This was compounded by a shared `getChildProp` function that assumed that the inner HTML of nested divs with the correct information could be parsed out without any problems. The `HTMLElement` generated HTML adds whitespace and newlines in pretty-print fashion. `getChildProps` was expecting a single string ("bottom", "top", whatever) *without any whitespace*. The presence of the whitespace is what threw off the popover module.
  
This PR does the following:
1.  Puts `data-placement` as a property on the anchor target for the source popover, rather than as information in a child div
2.  Changes `updatePopovers` `placement` function to explicitly read this value by passing the proper arguments to the callback and reading the internal dataset for that `data-placement` value
3.  Moves `updatePopovers` completely into `CellHandler`
## How Has This Been Tested?
Tested using the `UninitializableService` alert popover on the front page of the basic frontend test. Also ran the full `web` test suite and everything has passed.
<!-- Describe in reasonable detail how you tested your changes. -->
<!-- If appropriate, include details of your testing environment, -->
<!-- tests ran to see how your change affects other areas of the code, etc. --
  
## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.